### PR TITLE
Fix manual backup with multiple games selected asks for snapshot tag for each game

### DIFF
--- a/src/LudusaviRestic.cs
+++ b/src/LudusaviRestic.cs
@@ -222,9 +222,9 @@ namespace LudusaviRestic
                     MenuSection = GetLocalizedString("LOCLuduRestBackupGM", "LOCLuduRestBackupGM"),
 
                     Action = args => {
-                        foreach (var game in args.Games)
+                        if (CheckConfiguration() && args.Games.Count > 0)
                         {
-                            this.manager.PerformManualBackup(game);
+                            this.manager.PerformManualBackup(args.Games);
                         }
                     }
                 },

--- a/src/ResticBackupManager.cs
+++ b/src/ResticBackupManager.cs
@@ -73,6 +73,14 @@ namespace LudusaviRestic
 
         public void PerformManualBackup(Game game)
         {
+            IList<Game> games = new List<Game>();
+            games.Add(game);
+
+            PerformManualBackup(games);
+        }
+
+        public void PerformManualBackup(IList<Game> games)
+        {
             var tags = ManualBackupTags();
             // Prompt user for an optional custom tag
             var result = this.context.API.Dialogs.SelectString(
@@ -84,7 +92,10 @@ namespace LudusaviRestic
             {
                 tags.Add(result.SelectedString.Trim());
             }
-            PerformBackup(game, tags);
+            foreach (var game in games)
+            {
+                PerformBackup(game, tags);
+            }
         }
 
         public void PerformGameplayBackup(Game game)


### PR DESCRIPTION
Fixes #81 

### Notes
- `PerformManualBackup()` with a single Game argument is preserved, even though it isn't used anymore.
- This also calls `CheckConfiguration()` before trying to perform the action.