### PR TITLE
Fix release workflow and yq strenv for changelogs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
           git log $range --pretty=format:"%s" --no-merges --reverse | while IFS= read -r msg; do
-            ENTRY="$msg" yq -i '.Packages[0].Changelog += [env(ENTRY)]' manifest.yaml
+            ENTRY="$msg" yq -i '.Packages[0].Changelog += [strenv(ENTRY)]' manifest.yaml
           done
 
       - name: Create pull request

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,8 @@ jobs:
     name: "Release"
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v6
@@ -92,13 +94,18 @@ jobs:
         with:
           name: artifacts
 
+      - name: Build release notes from manifest
+        run: |
+          yq -r '.Packages[0].Changelog[] | "- " + .' manifest.yaml > notes.md
+
       - run: |
           mv LudusaviRestic_*.pext LudusaviRestic_v${{ steps.version.outputs.result }}.pext
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.ACTIONS_TOKEN }}"
-          prerelease: false
-          automatic_release_tag: "v${{ steps.version.outputs.result }}"
-          files: |
-            *.pext
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.result }}" \
+            --title "v${{ steps.version.outputs.result }}" \
+            --notes-file notes.md \
+            LudusaviRestic_v${{ steps.version.outputs.result }}.pext

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -72,7 +72,7 @@ tasks:
       yq -i '.Packages = [{"Version": env(VERSION), "RequiredApiVersion": env(REQUIRED_API), "ReleaseDate": env(RELEASE_DATE), "PackageUrl": env(PACKAGE_URL), "Changelog": []}] + .Packages' manifest.yaml
 
       git log $range --pretty=format:"%s" --no-merges --reverse | while IFS= read -r msg; do
-        ENTRY="$msg" yq -i '.Packages[0].Changelog += [env(ENTRY)]' manifest.yaml
+        ENTRY="$msg" yq -i '.Packages[0].Changelog += [strenv(ENTRY)]' manifest.yaml
       done
 
       echo ""


### PR DESCRIPTION
## Summary
- Replace `marvinpinto/action-automatic-releases` with `gh release create` using `GITHUB_TOKEN` (fixes bad credentials error)
- Use `strenv()` instead of `env()` in bump workflow/Taskfile for commit messages with colons

## Test plan
- [ ] Run bump workflow from GitHub Actions UI
- [ ] Run release workflow from GitHub Actions UI