### PR TITLE
chore: apply CLAUDE.md coding convention fixes

### DIFF
--- a/src/LudusaviRestic.cs
+++ b/src/LudusaviRestic.cs
@@ -19,8 +19,8 @@ namespace LudusaviRestic
 
         public override Guid Id { get; } = Guid.Parse("e9861c36-68a8-4654-8071-a9c50612bc24");
 
-        private ResticBackupManager manager;
-        private Timer timer;
+        private ResticBackupManager _manager;
+        private Timer _timer;
 
         public LudusaviRestic(IPlayniteAPI api) : base(api)
         {
@@ -29,7 +29,7 @@ namespace LudusaviRestic
             {
                 HasSettings = true
             };
-            this.manager = new ResticBackupManager(this.settings, this.PlayniteApi);
+            this._manager = new ResticBackupManager(this.settings, this.PlayniteApi);
         }
 
         private string GetLocalizedString(string key, string fallback = null)
@@ -81,7 +81,7 @@ namespace LudusaviRestic
                     Action = args => {
                         if (CheckConfiguration())
                         {
-                            this.manager.BackupAllGames();
+                            this._manager.BackupAllGames();
                         }
                     }
                 },
@@ -166,7 +166,7 @@ namespace LudusaviRestic
                     Action = args => {
                         if (CheckConfiguration() && args.Games.Count > 0)
                         {
-                            this.manager.PerformManualBackup(args.Games);
+                            this._manager.PerformManualBackup(args.Games);
                         }
                     }
                 },
@@ -774,11 +774,16 @@ namespace LudusaviRestic
             }
         }
 
+        public override void OnApplicationStopped(OnApplicationStoppedEventArgs args)
+        {
+            _timer?.Dispose();
+        }
+
         public override void OnGameUninstalled(OnGameUninstalledEventArgs args)
         {
             if (settings.BackupOnUninstall)
             {
-                this.manager.PerformBackup(args.Game);
+                this._manager.PerformBackup(args.Game);
             }
         }
 
@@ -789,7 +794,7 @@ namespace LudusaviRestic
             if (settings.BackupDuringGameplay)
             {
                 var interval = settings.GetEffectiveInterval(args.Game.Id);
-                this.timer = new Timer(GameplayBackupTimerElapsed, args.Game,
+                this._timer = new Timer(GameplayBackupTimerElapsed, args.Game,
                     interval * 60000,
                     interval * 60000);
             }
@@ -798,12 +803,12 @@ namespace LudusaviRestic
         private void GameplayBackupTimerElapsed(Object obj)
         {
             Game game = (Game)obj;
-            this.manager.PerformGameplayBackup(game);
+            this._manager.PerformGameplayBackup(game);
         }
 
         public override void OnGameStopped(OnGameStoppedEventArgs args)
         {
-            this.timer?.Dispose();
+            this._timer?.Dispose();
 
             if (this.settings.BackupWhenGameStopped)
             {
@@ -823,11 +828,11 @@ namespace LudusaviRestic
                         logger.Debug($"Custom backup tag provided: {result.SelectedString}");
                     }
 
-                    this.manager.PerformGameStoppedBackup(args.Game, result.SelectedString);
+                    this._manager.PerformGameStoppedBackup(args.Game, result.SelectedString);
                 }
                 else
                 {
-                    this.manager.PerformGameStoppedBackup(args.Game);
+                    this._manager.PerformGameStoppedBackup(args.Game);
                 }
             }
         }

--- a/src/LudusaviResticSettings.cs
+++ b/src/LudusaviResticSettings.cs
@@ -1,4 +1,4 @@
-﻿using Playnite.SDK;
+using Playnite.SDK;
 using System.Collections.Generic;
 using System;
 using System.ComponentModel;
@@ -7,7 +7,7 @@ namespace LudusaviRestic
 {
     public class LudusaviResticSettings : ISettings, INotifyPropertyChanged
     {
-        private readonly LudusaviRestic plugin;
+        private readonly LudusaviRestic _plugin;
         private static readonly ILogger logger = LogManager.GetLogger();
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -19,122 +19,122 @@ namespace LudusaviRestic
             }
         }
 
-        private string ludusaviExecutablePath = "ludusavi";
-        public string LudusaviExecutablePath { get { return ludusaviExecutablePath; } set { ludusaviExecutablePath = value; NotifyPropertyChanged("LudusaviExecutablePath"); } }
+        private string _ludusaviExecutablePath = "ludusavi";
+        public string LudusaviExecutablePath { get { return _ludusaviExecutablePath; } set { _ludusaviExecutablePath = value; NotifyPropertyChanged("LudusaviExecutablePath"); } }
 
-        private ExecutionMode backupExecutionMode = ExecutionMode.Exclude;
+        private ExecutionMode _backupExecutionMode = ExecutionMode.Exclude;
 
-        public ExecutionMode BackupExecutionMode { get { return backupExecutionMode; } set { backupExecutionMode = value; NotifyPropertyChanged("BackupExecutionMode"); } }
+        public ExecutionMode BackupExecutionMode { get { return _backupExecutionMode; } set { _backupExecutionMode = value; NotifyPropertyChanged("BackupExecutionMode"); } }
 
-        private Guid excludeTagID = Guid.Empty;
+        private Guid _excludeTagID = Guid.Empty;
         public Guid ExcludeTagID
         {
             get
             {
-                if (plugin != null && excludeTagID == Guid.Empty)
+                if (_plugin != null && _excludeTagID == Guid.Empty)
                 {
-                    excludeTagID = plugin.PlayniteApi.Database.Tags.Add("[LR] Exclude").Id;
+                    _excludeTagID = _plugin.PlayniteApi.Database.Tags.Add("[LR] Exclude").Id;
                 }
-                else if (plugin != null && plugin.PlayniteApi.Database.Tags.Get(excludeTagID) == null)
+                else if (_plugin != null && _plugin.PlayniteApi.Database.Tags.Get(_excludeTagID) == null)
                 {
-                    excludeTagID = plugin.PlayniteApi.Database.Tags.Add("[LR] Exclude").Id;
+                    _excludeTagID = _plugin.PlayniteApi.Database.Tags.Add("[LR] Exclude").Id;
                 }
-                return excludeTagID;
+                return _excludeTagID;
             }
-            set => excludeTagID = value;
+            set => _excludeTagID = value;
         }
-        private Guid includeTagID = Guid.Empty;
+        private Guid _includeTagID = Guid.Empty;
         public Guid IncludeTagID
         {
             get
             {
-                if (plugin != null && includeTagID == Guid.Empty)
+                if (_plugin != null && _includeTagID == Guid.Empty)
                 {
-                    includeTagID = plugin.PlayniteApi.Database.Tags.Add("[LR] Include").Id;
+                    _includeTagID = _plugin.PlayniteApi.Database.Tags.Add("[LR] Include").Id;
                 }
-                else if (plugin != null && plugin.PlayniteApi.Database.Tags.Get(includeTagID) == null)
+                else if (_plugin != null && _plugin.PlayniteApi.Database.Tags.Get(_includeTagID) == null)
                 {
-                    includeTagID = plugin.PlayniteApi.Database.Tags.Add("[LR] Include").Id;
+                    _includeTagID = _plugin.PlayniteApi.Database.Tags.Add("[LR] Include").Id;
                 }
-                return includeTagID;
+                return _includeTagID;
             }
-            set => includeTagID = value;
+            set => _includeTagID = value;
         }
 
-        private string resticExecutablePath = "restic";
-        public string ResticExecutablePath { get { return resticExecutablePath; } set { resticExecutablePath = value; NotifyPropertyChanged("ResticExecutablePath"); } }
-        private string resticRepository;
-        public string ResticRepository { get { return resticRepository; } set { resticRepository = value; NotifyPropertyChanged("ResticRepository"); } }
-        private string resticPassword;
-        public string ResticPassword { get { return resticPassword; } set { resticPassword = value; NotifyPropertyChanged("ResticPassword"); } }
-        private string rcloneConfigPath;
-        public string RcloneConfigPath { get { return rcloneConfigPath; } set { rcloneConfigPath = value; NotifyPropertyChanged("RcloneConfigPath"); } }
-        private string rcloneConfigPassword;
-        public string RcloneConfigPassword { get { return rcloneConfigPassword; } set { rcloneConfigPassword = value; NotifyPropertyChanged("RcloneConfigPassword"); } }
-        private bool backupDuringGameplay = false;
-        public bool BackupDuringGameplay { get { return backupDuringGameplay; } set { backupDuringGameplay = value; ; NotifyPropertyChanged("BackupDuringGameplay"); } }
-        private bool additionalTagging = false;
-        public bool AdditionalTagging { get { return additionalTagging; } set { additionalTagging = value; ; NotifyPropertyChanged("AdditionalTagging"); } }
-        private bool backupWhenGameStopped = true;
-        public bool BackupWhenGameStopped { get { return backupWhenGameStopped; } set { backupWhenGameStopped = value; ; NotifyPropertyChanged("BackupWhenGameStopped"); } }
-        private bool promptForGameStoppedTag = false;
-        public bool PromptForGameStoppedTag { get { return promptForGameStoppedTag; } set { promptForGameStoppedTag = value; ; NotifyPropertyChanged("PromptForGameStoppedTag"); } }
-        private bool backupOnUninstall = false;
-        public bool BackupOnUninstall { get { return backupOnUninstall; } set { backupOnUninstall = value; ; NotifyPropertyChanged("BackupOnUninstall"); } }
-        private string manualSnapshotTag = "manual";
-        public string ManualSnapshotTag { get { return manualSnapshotTag; } set { manualSnapshotTag = value; ; NotifyPropertyChanged("ManualSnapshotTag"); } }
-        private string gameStoppedSnapshotTag = "game-stopped";
-        public string GameStoppedSnapshotTag { get { return gameStoppedSnapshotTag; } set { gameStoppedSnapshotTag = value; ; NotifyPropertyChanged("GameStoppedSnapshotTag"); } }
-        private string gameplaySnapshotTag = "gameplay";
-        public string GameplaySnapshotTag { get { return gameplaySnapshotTag; } set { gameplaySnapshotTag = value; ; NotifyPropertyChanged("GameplaySnapshotTag"); } }
+        private string _resticExecutablePath = "restic";
+        public string ResticExecutablePath { get { return _resticExecutablePath; } set { _resticExecutablePath = value; NotifyPropertyChanged("ResticExecutablePath"); } }
+        private string _resticRepository;
+        public string ResticRepository { get { return _resticRepository; } set { _resticRepository = value; NotifyPropertyChanged("ResticRepository"); } }
+        private string _resticPassword;
+        public string ResticPassword { get { return _resticPassword; } set { _resticPassword = value; NotifyPropertyChanged("ResticPassword"); } }
+        private string _rcloneConfigPath;
+        public string RcloneConfigPath { get { return _rcloneConfigPath; } set { _rcloneConfigPath = value; NotifyPropertyChanged("RcloneConfigPath"); } }
+        private string _rcloneConfigPassword;
+        public string RcloneConfigPassword { get { return _rcloneConfigPassword; } set { _rcloneConfigPassword = value; NotifyPropertyChanged("RcloneConfigPassword"); } }
+        private bool _backupDuringGameplay = false;
+        public bool BackupDuringGameplay { get { return _backupDuringGameplay; } set { _backupDuringGameplay = value; ; NotifyPropertyChanged("BackupDuringGameplay"); } }
+        private bool _additionalTagging = false;
+        public bool AdditionalTagging { get { return _additionalTagging; } set { _additionalTagging = value; ; NotifyPropertyChanged("AdditionalTagging"); } }
+        private bool _backupWhenGameStopped = true;
+        public bool BackupWhenGameStopped { get { return _backupWhenGameStopped; } set { _backupWhenGameStopped = value; ; NotifyPropertyChanged("BackupWhenGameStopped"); } }
+        private bool _promptForGameStoppedTag = false;
+        public bool PromptForGameStoppedTag { get { return _promptForGameStoppedTag; } set { _promptForGameStoppedTag = value; ; NotifyPropertyChanged("PromptForGameStoppedTag"); } }
+        private bool _backupOnUninstall = false;
+        public bool BackupOnUninstall { get { return _backupOnUninstall; } set { _backupOnUninstall = value; ; NotifyPropertyChanged("BackupOnUninstall"); } }
+        private string _manualSnapshotTag = "manual";
+        public string ManualSnapshotTag { get { return _manualSnapshotTag; } set { _manualSnapshotTag = value; ; NotifyPropertyChanged("ManualSnapshotTag"); } }
+        private string _gameStoppedSnapshotTag = "game-stopped";
+        public string GameStoppedSnapshotTag { get { return _gameStoppedSnapshotTag; } set { _gameStoppedSnapshotTag = value; ; NotifyPropertyChanged("GameStoppedSnapshotTag"); } }
+        private string _gameplaySnapshotTag = "gameplay";
+        public string GameplaySnapshotTag { get { return _gameplaySnapshotTag; } set { _gameplaySnapshotTag = value; ; NotifyPropertyChanged("GameplaySnapshotTag"); } }
 
-        private NotificationLevel notificationLevel = NotificationLevel.Summary;
-        public NotificationLevel NotificationLevel { get { return notificationLevel; } set { notificationLevel = value; NotifyPropertyChanged("NotificationLevel"); } }
+        private NotificationLevel _notificationLevel = NotificationLevel.Summary;
+        public NotificationLevel NotificationLevel { get { return _notificationLevel; } set { _notificationLevel = value; NotifyPropertyChanged("NotificationLevel"); } }
 
-        private bool notifyOnManualBackup = true;
-        public bool NotifyOnManualBackup { get { return notifyOnManualBackup; } set { notifyOnManualBackup = value; NotifyPropertyChanged("NotifyOnManualBackup"); } }
+        private bool _notifyOnManualBackup = true;
+        public bool NotifyOnManualBackup { get { return _notifyOnManualBackup; } set { _notifyOnManualBackup = value; NotifyPropertyChanged("NotifyOnManualBackup"); } }
 
-        private bool enableRetentionPolicy = false;
-        public bool EnableRetentionPolicy { get { return enableRetentionPolicy; } set { enableRetentionPolicy = value; NotifyPropertyChanged("EnableRetentionPolicy"); } }
+        private bool _enableRetentionPolicy = false;
+        public bool EnableRetentionPolicy { get { return _enableRetentionPolicy; } set { _enableRetentionPolicy = value; NotifyPropertyChanged("EnableRetentionPolicy"); } }
 
-        private int keepLast = 10;
-        public int KeepLast { get { return keepLast; } set { keepLast = value; NotifyPropertyChanged("KeepLast"); } }
+        private int _keepLast = 10;
+        public int KeepLast { get { return _keepLast; } set { _keepLast = value; NotifyPropertyChanged("KeepLast"); } }
 
-        private int keepDaily = 7;
-        public int KeepDaily { get { return keepDaily; } set { keepDaily = value; NotifyPropertyChanged("KeepDaily"); } }
+        private int _keepDaily = 7;
+        public int KeepDaily { get { return _keepDaily; } set { _keepDaily = value; NotifyPropertyChanged("KeepDaily"); } }
 
-        private int keepWeekly = 4;
-        public int KeepWeekly { get { return keepWeekly; } set { keepWeekly = value; NotifyPropertyChanged("KeepWeekly"); } }
+        private int _keepWeekly = 4;
+        public int KeepWeekly { get { return _keepWeekly; } set { _keepWeekly = value; NotifyPropertyChanged("KeepWeekly"); } }
 
-        private int keepMonthly = 12;
-        public int KeepMonthly { get { return keepMonthly; } set { keepMonthly = value; NotifyPropertyChanged("KeepMonthly"); } }
+        private int _keepMonthly = 12;
+        public int KeepMonthly { get { return _keepMonthly; } set { _keepMonthly = value; NotifyPropertyChanged("KeepMonthly"); } }
 
-        private int keepYearly = 5;
-        public int KeepYearly { get { return keepYearly; } set { keepYearly = value; NotifyPropertyChanged("KeepYearly"); } }
+        private int _keepYearly = 5;
+        public int KeepYearly { get { return _keepYearly; } set { _keepYearly = value; NotifyPropertyChanged("KeepYearly"); } }
 
-        private int maxRepackSizeMB = 500;
-        public int MaxRepackSizeMB { get { return maxRepackSizeMB; } set { maxRepackSizeMB = value; NotifyPropertyChanged("MaxRepackSizeMB"); } }
+        private int _maxRepackSizeMB = 500;
+        public int MaxRepackSizeMB { get { return _maxRepackSizeMB; } set { _maxRepackSizeMB = value; NotifyPropertyChanged("MaxRepackSizeMB"); } }
 
-        private Dictionary<string, GameOverride> gameIntervalOverrides = new Dictionary<string, GameOverride>();
+        private Dictionary<string, GameOverride> _gameIntervalOverrides = new Dictionary<string, GameOverride>();
         public Dictionary<string, GameOverride> GameIntervalOverrides
         {
-            get { return gameIntervalOverrides; }
-            set { gameIntervalOverrides = value ?? new Dictionary<string, GameOverride>(); }
+            get { return _gameIntervalOverrides; }
+            set { _gameIntervalOverrides = value ?? new Dictionary<string, GameOverride>(); }
         }
 
-        private List<Guid> excludedSourceIds = new List<Guid>();
+        private List<Guid> _excludedSourceIds = new List<Guid>();
         public List<Guid> ExcludedSourceIds
         {
-            get { return excludedSourceIds; }
-            set { excludedSourceIds = value ?? new List<Guid>(); }
+            get { return _excludedSourceIds; }
+            set { _excludedSourceIds = value ?? new List<Guid>(); }
         }
 
-        private List<string> errors;
+        private List<string> _errors;
 
-        private int gameplayBackupInterval = 5;
+        private int _gameplayBackupInterval = 5;
         public int GameplayBackupInterval
         {
-            get { return gameplayBackupInterval; }
+            get { return _gameplayBackupInterval; }
             set
             {
                 string rawValue = value.ToString();
@@ -144,12 +144,12 @@ namespace LudusaviRestic
 
                 if (success)
                 {
-                    gameplayBackupInterval = intValue;
+                    _gameplayBackupInterval = intValue;
                     NotifyPropertyChanged("GameplayBackupInterval");
                 }
                 else
                 {
-                    this.errors.Add("Backup interval must be a positive integer");
+                    this._errors.Add("Backup interval must be a positive integer");
                 }
             }
         }
@@ -161,13 +161,13 @@ namespace LudusaviRestic
         public LudusaviResticSettings(LudusaviRestic plugin)
         {
             // Injecting your plugin instance is required for Save/Load method because Playnite saves data to a location based on what plugin requested the operation.
-            this.plugin = plugin;
+            this._plugin = plugin;
             Load();
         }
         private void Load()
         {
             // Load saved settings.
-            var savedSettings = plugin.LoadPluginSettings<LudusaviResticSettings>();
+            var savedSettings = _plugin.LoadPluginSettings<LudusaviResticSettings>();
 
             // LoadPluginSettings returns null if not saved data is available.
             if (savedSettings != null)
@@ -191,9 +191,9 @@ namespace LudusaviRestic
 
                 // Load tag IDs if available
                 if (savedSettings.ExcludeTagID != Guid.Empty)
-                    excludeTagID = savedSettings.ExcludeTagID;
+                    _excludeTagID = savedSettings.ExcludeTagID;
                 if (savedSettings.IncludeTagID != Guid.Empty)
-                    includeTagID = savedSettings.IncludeTagID;
+                    _includeTagID = savedSettings.IncludeTagID;
 
                 // Load retention policy settings
                 KeepLast = savedSettings.KeepLast;
@@ -257,7 +257,7 @@ namespace LudusaviRestic
         internal int GetEffectiveInterval(Guid gameId)
         {
             GameOverride over;
-            if (gameIntervalOverrides.TryGetValue(gameId.ToString(), out over) && over.HasIntervalOverride)
+            if (_gameIntervalOverrides.TryGetValue(gameId.ToString(), out over) && over.HasIntervalOverride)
             {
                 return over.IntervalMinutes.Value;
             }
@@ -266,7 +266,7 @@ namespace LudusaviRestic
 
         internal GameOverride FindOverrideByGameName(string gameName)
         {
-            foreach (var kvp in gameIntervalOverrides)
+            foreach (var kvp in _gameIntervalOverrides)
             {
                 if (string.Equals(kvp.Value.GameName, gameName, System.StringComparison.OrdinalIgnoreCase))
                 {
@@ -279,7 +279,7 @@ namespace LudusaviRestic
 
         public void BeginEdit()
         {
-            this.errors = new List<string>();
+            this._errors = new List<string>();
         }
 
         public void CancelEdit()
@@ -292,7 +292,7 @@ namespace LudusaviRestic
         public void Save()
         {
             // The plugin base class provides SavePluginSettings method
-            plugin.SavePluginSettings(this);
+            _plugin.SavePluginSettings(this);
         }
 
         public void EndEdit()
@@ -302,8 +302,8 @@ namespace LudusaviRestic
 
         public bool VerifySettings(out List<string> errors)
         {
-            errors = new List<string>(this.errors);
-            this.errors.Clear();
+            errors = new List<string>(this._errors);
+            this._errors.Clear();
             return errors.Count == 0;
         }
     }

--- a/src/Models/BackupContext.cs
+++ b/src/Models/BackupContext.cs
@@ -6,16 +6,16 @@ namespace LudusaviRestic
     public class BackupContext
     {
         public readonly string NotificationID = "LudusaviRestic";
-        private IPlayniteAPI api;
-        private LudusaviResticSettings settings;
+        private IPlayniteAPI _api;
+        private LudusaviResticSettings _settings;
 
-        public IPlayniteAPI API { get { return this.api; } }
-        public LudusaviResticSettings Settings { get { return this.settings; } }
+        public IPlayniteAPI API { get { return this._api; } }
+        public LudusaviResticSettings Settings { get { return this._settings; } }
 
         public BackupContext(IPlayniteAPI api, LudusaviResticSettings settings)
         {
-            this.api = api;
-            this.settings = settings;
+            this._api = api;
+            this._settings = settings;
             ApplyEnvironment();
         }
 
@@ -26,10 +26,10 @@ namespace LudusaviRestic
 
         public void ApplyEnvironment()
         {
-            Environment.SetEnvironmentVariable("RCLONE_CONFIG_PASS", this.settings.RcloneConfigPassword);
-            Environment.SetEnvironmentVariable("RESTIC_REPOSITORY", this.settings.ResticRepository);
-            Environment.SetEnvironmentVariable("RESTIC_PASSWORD", this.settings.ResticPassword);
-            Environment.SetEnvironmentVariable("RCLONE_CONFIG", this.settings.RcloneConfigPath);
+            Environment.SetEnvironmentVariable("RCLONE_CONFIG_PASS", this._settings.RcloneConfigPassword);
+            Environment.SetEnvironmentVariable("RESTIC_REPOSITORY", this._settings.ResticRepository);
+            Environment.SetEnvironmentVariable("RESTIC_PASSWORD", this._settings.ResticPassword);
+            Environment.SetEnvironmentVariable("RCLONE_CONFIG", this._settings.RcloneConfigPath);
         }
     }
 }

--- a/src/Models/CommandResult.cs
+++ b/src/Models/CommandResult.cs
@@ -8,28 +8,28 @@ namespace LudusaviRestic
 {
     public class CommandResult
     {
-        private int exitCode;
-        private string stdout;
-        private string stderr;
+        private int _exitCode;
+        private string _stdout;
+        private string _stderr;
 
-        public int ExitCode { get { return this.exitCode; } }
-        public string StdOut { get { return this.stdout; } }
-        public string StdErr { get { return this.stderr; } }
+        public int ExitCode { get { return this._exitCode; } }
+        public string StdOut { get { return this._stdout; } }
+        public string StdErr { get { return this._stderr; } }
 
         internal CommandResult(int exitCode, string stdout, string stderr)
         {
-            this.exitCode = exitCode;
-            this.stdout = stdout;
-            this.stderr = stderr;
+            this._exitCode = exitCode;
+            this._stdout = stdout;
+            this._stderr = stderr;
         }
 
         public CommandResult(Process process)
         {
             process.Start();
-            this.stdout = TransformProcessOutput(process.StandardOutput.ReadToEnd());
+            this._stdout = TransformProcessOutput(process.StandardOutput.ReadToEnd());
             process.WaitForExit(4000);
-            this.stderr = TransformProcessOutput(process.StandardError.ReadToEnd());
-            this.exitCode = process.ExitCode;
+            this._stderr = TransformProcessOutput(process.StandardError.ReadToEnd());
+            this._exitCode = process.ExitCode;
         }
 
         internal static string TransformProcessOutput(string output)

--- a/src/Models/PruneResult.cs
+++ b/src/Models/PruneResult.cs
@@ -58,7 +58,7 @@ namespace LudusaviRestic
         }
     }
 
-    public static class PruneResultParser
+    internal static class PruneResultParser
     {
         private static readonly ILogger logger = LogManager.GetLogger();
         public static PruneResult ParsePruneOutput(CommandResult result, bool isDryRun = false)
@@ -83,7 +83,7 @@ namespace LudusaviRestic
             catch (Exception ex)
             {
                 // If parsing fails, we still have the raw output
-                System.Diagnostics.Debug.WriteLine($"Error parsing prune output: {ex.Message}");
+                logger.Debug(ex, "Error parsing prune output, raw output preserved");
             }
 
             return pruneResult;
@@ -109,7 +109,7 @@ namespace LudusaviRestic
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error parsing forget output: {ex.Message}");
+                logger.Debug(ex, "Error parsing forget output, raw output preserved");
             }
 
             return pruneResult;
@@ -146,9 +146,10 @@ namespace LudusaviRestic
                     ParseDeletedSnapshotsText(result, output);
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // If JSON parsing fails, fall back to text parsing
+                logger.Debug(ex, "JSON parsing failed, falling back to text parser");
                 ParseDeletedSnapshotsText(result, output);
             }
 
@@ -266,7 +267,7 @@ namespace LudusaviRestic
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error parsing forget JSON: {ex.Message}");
+                logger.Error(ex, "Error parsing forget JSON");
             }
         }
 

--- a/src/Tasks/BackupGameTask.cs
+++ b/src/Tasks/BackupGameTask.cs
@@ -10,24 +10,24 @@ namespace LudusaviRestic
 {
     public class BackupGameTask : BaseBackupTask
     {
-        private Game game;
-        private bool isManual;
+        private Game _game;
+        private bool _isManual;
 
         public BackupGameTask(Game game, SemaphoreSlim semaphore, BackupContext context, bool isManual = false) : base(semaphore, context)
         {
-            this.game = game;
-            this.isManual = isManual;
+            this._game = game;
+            this._isManual = isManual;
         }
 
         public BackupGameTask(Game game, SemaphoreSlim semaphore, BackupContext context, IList<string> extraTags, bool isManual = false) : base(semaphore, context, extraTags)
         {
-            this.game = game;
-            this.isManual = isManual;
+            this._game = game;
+            this._isManual = isManual;
         }
 
         protected override void Backup()
         {
-            Backup(this.semaphore, this.context, this.game, this.extraTags, this.isManual);
+            Backup(this.semaphore, this.context, this._game, this.extraTags, this._isManual);
         }
 
         internal static IList<string> ParseGameFiles(string gameName, string ludusaviJson)

--- a/src/Tasks/BaseBackupTask.cs
+++ b/src/Tasks/BaseBackupTask.cs
@@ -95,17 +95,14 @@ namespace LudusaviRestic
         private static string WriteFilesToTempFile(IList<string> files)
         {
             string listfile = System.IO.Path.GetTempFileName();
-            System.IO.FileInfo listfileinfo = new System.IO.FileInfo(listfile);
-            listfileinfo.Attributes = System.IO.FileAttributes.Temporary;
-            System.IO.StreamWriter listfilewriter = System.IO.File.AppendText(listfile);
-
-            foreach (string filename in files)
+            new System.IO.FileInfo(listfile).Attributes = System.IO.FileAttributes.Temporary;
+            using (var writer = System.IO.File.AppendText(listfile))
             {
-                listfilewriter.WriteLine(NormalizePath(filename));
+                foreach (string filename in files)
+                {
+                    writer.WriteLine(NormalizePath(filename));
+                }
             }
-            listfilewriter.Flush();
-            listfilewriter.Close();
-
             return listfile;
         }
 

--- a/src/Tasks/ResticBackupManager.cs
+++ b/src/Tasks/ResticBackupManager.cs
@@ -9,23 +9,23 @@ namespace LudusaviRestic
     public class ResticBackupManager
     {
         private static readonly ILogger logger = LogManager.GetLogger();
-        private BackupContext context;
-        private SemaphoreSlim semaphore;
+        private BackupContext _context;
+        private SemaphoreSlim _semaphore;
 
         public ResticBackupManager(LudusaviResticSettings settings, IPlayniteAPI api)
         {
-            this.semaphore = new SemaphoreSlim(1);
-            this.context = new BackupContext(api, settings);
+            this._semaphore = new SemaphoreSlim(1);
+            this._context = new BackupContext(api, settings);
         }
 
         public void BackupAllGames()
         {
-            new BackupAllTask(this.semaphore, this.context, new List<string>()).Run();
+            new BackupAllTask(this._semaphore, this._context, new List<string>()).Run();
         }
 
         public void BackupAllGames(IList<string> extraTags)
         {
-            new BackupAllTask(this.semaphore, this.context, extraTags).Run();
+            new BackupAllTask(this._semaphore, this._context, extraTags).Run();
         }
 
         public void PerformBackup(Game game)
@@ -68,7 +68,7 @@ namespace LudusaviRestic
         public void PerformBackup(Game game, IList<string> extraTags, bool isManual = false)
         {
             logger.Debug($"Backup #{game.Name}");
-            LudusaviResticSettings settings = this.context.Settings;
+            LudusaviResticSettings settings = this._context.Settings;
 
             if (ShouldSkipBackup(settings.BackupExecutionMode, game, settings.ExcludeTagID, settings.IncludeTagID, settings.ExcludedSourceIds))
             {
@@ -76,7 +76,7 @@ namespace LudusaviRestic
                 return;
             }
 
-            BackupGameTask task = new BackupGameTask(game, this.semaphore, this.context, extraTags, isManual);
+            BackupGameTask task = new BackupGameTask(game, this._semaphore, this._context, extraTags, isManual);
             task.Run();
         }
 
@@ -105,7 +105,7 @@ namespace LudusaviRestic
         {
             var tags = ManualBackupTags();
             // Prompt user for an optional custom tag
-            var result = this.context.API.Dialogs.SelectString(
+            var result = this._context.API.Dialogs.SelectString(
                 ResourceProvider.GetString("LOCLuduRestManualBackupTagPrompt"),
                 ResourceProvider.GetString("LOCLuduRestManualBackupTagTitle"),
                 ""
@@ -127,17 +127,17 @@ namespace LudusaviRestic
 
         private IList<string> ManualBackupTags()
         {
-            return BuildBackupTags(this.context.Settings.AdditionalTagging, this.context.Settings.ManualSnapshotTag);
+            return BuildBackupTags(this._context.Settings.AdditionalTagging, this._context.Settings.ManualSnapshotTag);
         }
 
         private IList<string> GameplayBackupTags()
         {
-            return BuildBackupTags(this.context.Settings.AdditionalTagging, this.context.Settings.GameplaySnapshotTag);
+            return BuildBackupTags(this._context.Settings.AdditionalTagging, this._context.Settings.GameplaySnapshotTag);
         }
 
         private IList<string> GamestoppedBackupTags()
         {
-            return BuildBackupTags(this.context.Settings.AdditionalTagging, this.context.Settings.GameStoppedSnapshotTag);
+            return BuildBackupTags(this._context.Settings.AdditionalTagging, this._context.Settings.GameStoppedSnapshotTag);
         }
     }
 }

--- a/src/Utilities/ResticUtility.cs
+++ b/src/Utilities/ResticUtility.cs
@@ -138,7 +138,7 @@ namespace LudusaviRestic
                 // For "restic" (no path), check if it's available in PATH
                 if (path == "restic")
                 {
-                    var process = new Process
+                    using (var process = new Process
                     {
                         StartInfo = new ProcessStartInfo
                         {
@@ -150,20 +150,20 @@ namespace LudusaviRestic
                             CreateNoWindow = true,
                             WindowStyle = ProcessWindowStyle.Hidden
                         }
-                    };
-
-                    process.Start();
-                    var output = process.StandardOutput.ReadToEnd();
-                    process.WaitForExit();
-
-                    return process.ExitCode == 0 && output.Contains("restic");
+                    })
+                    {
+                        process.Start();
+                        var output = process.StandardOutput.ReadToEnd();
+                        process.WaitForExit();
+                        return process.ExitCode == 0 && output.Contains("restic");
+                    }
                 }
 
                 // For full paths, check if file exists and is executable
                 if (!File.Exists(path))
                     return false;
 
-                var fileProcess = new Process
+                using (var fileProcess = new Process
                 {
                     StartInfo = new ProcessStartInfo
                     {
@@ -175,13 +175,13 @@ namespace LudusaviRestic
                         CreateNoWindow = true,
                         WindowStyle = ProcessWindowStyle.Hidden
                     }
-                };
-
-                fileProcess.Start();
-                var fileOutput = fileProcess.StandardOutput.ReadToEnd();
-                fileProcess.WaitForExit();
-
-                return fileProcess.ExitCode == 0 && fileOutput.Contains("restic");
+                })
+                {
+                    fileProcess.Start();
+                    var fileOutput = fileProcess.StandardOutput.ReadToEnd();
+                    fileProcess.WaitForExit();
+                    return fileProcess.ExitCode == 0 && fileOutput.Contains("restic");
+                }
             }
             catch (Exception ex)
             {
@@ -205,7 +205,7 @@ namespace LudusaviRestic
                 // For "ludusavi" (no path), check if it's available in PATH
                 if (path == "ludusavi")
                 {
-                    var process = new Process
+                    using (var process = new Process
                     {
                         StartInfo = new ProcessStartInfo
                         {
@@ -217,20 +217,20 @@ namespace LudusaviRestic
                             CreateNoWindow = true,
                             WindowStyle = ProcessWindowStyle.Hidden
                         }
-                    };
-
-                    process.Start();
-                    var output = process.StandardOutput.ReadToEnd();
-                    process.WaitForExit();
-
-                    return process.ExitCode == 0 && output.ToLower().Contains("ludusavi");
+                    })
+                    {
+                        process.Start();
+                        var output = process.StandardOutput.ReadToEnd();
+                        process.WaitForExit();
+                        return process.ExitCode == 0 && output.ToLower().Contains("ludusavi");
+                    }
                 }
 
                 // For full paths, check if file exists and is executable
                 if (!File.Exists(path))
                     return false;
 
-                var fileProcess = new Process
+                using (var fileProcess = new Process
                 {
                     StartInfo = new ProcessStartInfo
                     {
@@ -242,13 +242,13 @@ namespace LudusaviRestic
                         CreateNoWindow = true,
                         WindowStyle = ProcessWindowStyle.Hidden
                     }
-                };
-
-                fileProcess.Start();
-                var fileOutput = fileProcess.StandardOutput.ReadToEnd();
-                fileProcess.WaitForExit();
-
-                return fileProcess.ExitCode == 0 && fileOutput.ToLower().Contains("ludusavi");
+                })
+                {
+                    fileProcess.Start();
+                    var fileOutput = fileProcess.StandardOutput.ReadToEnd();
+                    fileProcess.WaitForExit();
+                    return fileProcess.ExitCode == 0 && fileOutput.ToLower().Contains("ludusavi");
+                }
             }
             catch (Exception ex)
             {
@@ -279,7 +279,7 @@ namespace LudusaviRestic
             var tempContext = new BackupContext(context.API, tempSettings);
 
             // Execute restic init command
-            var process = new Process
+            using (var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
@@ -291,16 +291,17 @@ namespace LudusaviRestic
                     CreateNoWindow = true,
                     WindowStyle = ProcessWindowStyle.Hidden
                 }
-            };
+            })
+            {
+                // Set environment variables for restic
+                process.StartInfo.Environment["RESTIC_REPOSITORY"] = repositoryPath;
+                process.StartInfo.Environment["RESTIC_PASSWORD"] = password;
 
-            // Set environment variables for restic
-            process.StartInfo.Environment["RESTIC_REPOSITORY"] = repositoryPath;
-            process.StartInfo.Environment["RESTIC_PASSWORD"] = password;
+                logger.Debug($"Executing: {process.StartInfo.FileName} {process.StartInfo.Arguments}");
+                logger.Debug($"Repository: {repositoryPath}");
 
-            logger.Debug($"Executing: {process.StartInfo.FileName} {process.StartInfo.Arguments}");
-            logger.Debug($"Repository: {repositoryPath}");
-
-            return new CommandResult(process);
+                return new CommandResult(process);
+            }
         }
 
         /// <summary>

--- a/src/Views/BackupBrowserViewModel.cs
+++ b/src/Views/BackupBrowserViewModel.cs
@@ -16,27 +16,27 @@ namespace LudusaviRestic
     public class BackupBrowserViewModel : INotifyPropertyChanged
     {
         private static readonly ILogger logger = LogManager.GetLogger();
-        private BackupContext context;
-        private ObservableCollection<BackupSnapshot> snapshots;
-        private ObservableCollection<BackupSnapshot> allSnapshots;
-        private BackupSnapshot selectedSnapshot;
-        private bool isLoading;
-        private string selectedGameFilter;
-        private ObservableCollection<string> gameFilters;
+        private BackupContext _context;
+        private ObservableCollection<BackupSnapshot> _snapshots;
+        private ObservableCollection<BackupSnapshot> _allSnapshots;
+        private BackupSnapshot _selectedSnapshot;
+        private bool _isLoading;
+        private string _selectedGameFilter;
+        private ObservableCollection<string> _gameFilters;
 
         public ObservableCollection<BackupSnapshot> Snapshots
         {
-            get => snapshots;
+            get => _snapshots;
             set
             {
-                if (snapshots != null)
+                if (_snapshots != null)
                 {
-                    snapshots.CollectionChanged -= Snapshots_CollectionChanged;
+                    _snapshots.CollectionChanged -= Snapshots_CollectionChanged;
                 }
-                snapshots = value;
-                if (snapshots != null)
+                _snapshots = value;
+                if (_snapshots != null)
                 {
-                    snapshots.CollectionChanged += Snapshots_CollectionChanged;
+                    _snapshots.CollectionChanged += Snapshots_CollectionChanged;
                 }
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(SnapshotCount));
@@ -52,20 +52,20 @@ namespace LudusaviRestic
 
         public ObservableCollection<string> GameFilters
         {
-            get => gameFilters;
+            get => _gameFilters;
             set
             {
-                gameFilters = value;
+                _gameFilters = value;
                 OnPropertyChanged();
             }
         }
 
         public string SelectedGameFilter
         {
-            get => selectedGameFilter;
+            get => _selectedGameFilter;
             set
             {
-                selectedGameFilter = value;
+                _selectedGameFilter = value;
                 OnPropertyChanged();
                 ApplyFilter();
             }
@@ -73,20 +73,20 @@ namespace LudusaviRestic
 
         public BackupSnapshot SelectedSnapshot
         {
-            get => selectedSnapshot;
+            get => _selectedSnapshot;
             set
             {
-                selectedSnapshot = value;
+                _selectedSnapshot = value;
                 OnPropertyChanged();
             }
         }
 
         public bool IsLoading
         {
-            get => isLoading;
+            get => _isLoading;
             set
             {
-                isLoading = value;
+                _isLoading = value;
                 OnPropertyChanged();
             }
         }
@@ -96,9 +96,9 @@ namespace LudusaviRestic
 
         public BackupBrowserViewModel(BackupContext context)
         {
-            this.context = context;
+            this._context = context;
             this.Snapshots = new ObservableCollection<BackupSnapshot>();
-            this.allSnapshots = new ObservableCollection<BackupSnapshot>();
+            this._allSnapshots = new ObservableCollection<BackupSnapshot>();
             this.GameFilters = new ObservableCollection<string>();
 
             RefreshCommand = new RelayCommand(RefreshSnapshots);
@@ -108,11 +108,11 @@ namespace LudusaviRestic
 
         public BackupBrowserViewModel(BackupContext context, string gameFilter)
         {
-            this.context = context;
+            this._context = context;
             this.Snapshots = new ObservableCollection<BackupSnapshot>();
-            this.allSnapshots = new ObservableCollection<BackupSnapshot>();
+            this._allSnapshots = new ObservableCollection<BackupSnapshot>();
             this.GameFilters = new ObservableCollection<string>();
-            this.selectedGameFilter = gameFilter; // preset desired filter; will be applied after load
+            this._selectedGameFilter = gameFilter; // preset desired filter; will be applied after load
             RefreshCommand = new RelayCommand(RefreshSnapshots);
             DeleteSnapshotCommand = new RelayCommand(DeleteSnapshot, CanDeleteSnapshot);
             RefreshSnapshots();
@@ -130,8 +130,8 @@ namespace LudusaviRestic
 
         private void ApplyFilter()
         {
-            if (allSnapshots == null) return;
-            Snapshots = new ObservableCollection<BackupSnapshot>(FilterSnapshots(allSnapshots, SelectedGameFilter));
+            if (_allSnapshots == null) return;
+            Snapshots = new ObservableCollection<BackupSnapshot>(FilterSnapshots(_allSnapshots, SelectedGameFilter));
         }
 
         internal static IList<BackupSnapshot> ParseSnapshots(string json)
@@ -166,20 +166,20 @@ namespace LudusaviRestic
             )
             { IsIndeterminate = true };
 
-            context.API.Dialogs.ActivateGlobalProgress(_ =>
+            _context.API.Dialogs.ActivateGlobalProgress(_ =>
             {
                 try
                 {
-                    var result = ResticCommand.ListSnapshots(context);
+                    var result = ResticCommand.ListSnapshots(_context);
                     if (result.ExitCode == 0)
                     {
                         var parsed = ParseSnapshots(result.StdOut);
-                        allSnapshots = new ObservableCollection<BackupSnapshot>(parsed);
+                        _allSnapshots = new ObservableCollection<BackupSnapshot>(parsed);
                         GameFilters = new ObservableCollection<string>(BuildGameFilters(parsed));
                         // If a specific game filter was preset (e.g., via game context menu), try to apply it
-                        if (!string.IsNullOrEmpty(selectedGameFilter) && GameFilters.Contains(selectedGameFilter))
+                        if (!string.IsNullOrEmpty(_selectedGameFilter) && GameFilters.Contains(_selectedGameFilter))
                         {
-                            SelectedGameFilter = selectedGameFilter; // triggers ApplyFilter()
+                            SelectedGameFilter = _selectedGameFilter; // triggers ApplyFilter()
                         }
                         else
                         {
@@ -196,13 +196,13 @@ namespace LudusaviRestic
                     else
                     {
                         logger.Error($"Failed to list snapshots: {result.StdErr}");
-                        context.API.Dialogs.ShowErrorMessage(ResourceProvider.GetString("LOCLuduRestFailedToLoadSnapshots"));
+                        _context.API.Dialogs.ShowErrorMessage(ResourceProvider.GetString("LOCLuduRestFailedToLoadSnapshots"));
                     }
                 }
                 catch (Exception ex)
                 {
                     logger.Error(ex, "Error loading snapshots");
-                    context.API.Dialogs.ShowErrorMessage(string.Format(ResourceProvider.GetString("LOCLuduRestErrorLoadingSnapshots"), ex.Message));
+                    _context.API.Dialogs.ShowErrorMessage(string.Format(ResourceProvider.GetString("LOCLuduRestErrorLoadingSnapshots"), ex.Message));
                 }
             }, globalProgressOptions);
         }
@@ -221,7 +221,7 @@ namespace LudusaviRestic
         private void DeleteSnapshot()
         {
             if (SelectedSnapshot == null) return;
-            var result = context.API.Dialogs.ShowMessage(
+            var result = _context.API.Dialogs.ShowMessage(
                 string.Format(ResourceProvider.GetString("LOCLuduRestDeleteSnapshotConfirmation"), SelectedSnapshot.ShortId, SelectedSnapshot.Date.ToString("yyyy-MM-dd HH:mm")),
                 ResourceProvider.GetString("LOCLuduRestDeleteBackupSnapshot"),
                 System.Windows.MessageBoxButton.YesNo,
@@ -229,23 +229,23 @@ namespace LudusaviRestic
             if (result != System.Windows.MessageBoxResult.Yes) return;
             try
             {
-                var deleteResult = ResticCommand.ForgetSnapshot(context, SelectedSnapshot.Id);
+                var deleteResult = ResticCommand.ForgetSnapshot(_context, SelectedSnapshot.Id);
                 if (deleteResult.ExitCode == 0)
                 {
-                    RemoveSnapshotFromCache(allSnapshots, Snapshots, SelectedSnapshot);
+                    RemoveSnapshotFromCache(_allSnapshots, Snapshots, SelectedSnapshot);
                     SelectedSnapshot = null;
-                    context.API.Dialogs.ShowMessage(ResourceProvider.GetString("LOCLuduRestSnapshotDeletedSuccessfully"), ResourceProvider.GetString("LOCLuduRestSuccess"));
+                    _context.API.Dialogs.ShowMessage(ResourceProvider.GetString("LOCLuduRestSnapshotDeletedSuccessfully"), ResourceProvider.GetString("LOCLuduRestSuccess"));
                 }
                 else
                 {
                     logger.Error($"Failed to delete snapshot: {deleteResult.StdErr}");
-                    context.API.Dialogs.ShowErrorMessage(string.Format(ResourceProvider.GetString("LOCLuduRestFailedToDeleteSnapshot"), deleteResult.StdErr));
+                    _context.API.Dialogs.ShowErrorMessage(string.Format(ResourceProvider.GetString("LOCLuduRestFailedToDeleteSnapshot"), deleteResult.StdErr));
                 }
             }
             catch (Exception ex)
             {
                 logger.Error(ex, "Error deleting snapshot");
-                context.API.Dialogs.ShowErrorMessage(string.Format(ResourceProvider.GetString("LOCLuduRestErrorDeletingSnapshot"), ex.Message));
+                _context.API.Dialogs.ShowErrorMessage(string.Format(ResourceProvider.GetString("LOCLuduRestErrorDeletingSnapshot"), ex.Message));
             }
         }
 
@@ -256,15 +256,15 @@ namespace LudusaviRestic
         }
     }
 
-    public class RelayCommand : ICommand
+    internal class RelayCommand : ICommand
     {
-        private readonly Action execute;
-        private readonly Func<bool> canExecute;
+        private readonly Action _execute;
+        private readonly Func<bool> _canExecute;
 
         public RelayCommand(Action execute, Func<bool> canExecute = null)
         {
-            this.execute = execute ?? throw new ArgumentNullException(nameof(execute));
-            this.canExecute = canExecute;
+            this._execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            this._canExecute = canExecute;
         }
 
         public event EventHandler CanExecuteChanged
@@ -275,12 +275,12 @@ namespace LudusaviRestic
 
         public bool CanExecute(object parameter)
         {
-            return canExecute?.Invoke() ?? true;
+            return _canExecute?.Invoke() ?? true;
         }
 
         public void Execute(object parameter)
         {
-            execute();
+            _execute();
         }
     }
 }

--- a/src/Views/LudusaviResticSettingsView.xaml.cs
+++ b/src/Views/LudusaviResticSettingsView.xaml.cs
@@ -11,14 +11,14 @@ namespace LudusaviRestic
 {
     public partial class LudusaviResticSettingsView : UserControl
     {
-        private LudusaviRestic plugin;
+        private LudusaviRestic _plugin;
         private static readonly ILogger logger = LogManager.GetLogger();
 
         public LudusaviResticSettingsView(LudusaviRestic plugin)
         {
             logger.Debug("LudusaviResticSettingsView init");
             InitializeComponent();
-            this.plugin = plugin;
+            this._plugin = plugin;
             // Initialize password fields with current settings values
             Loaded += (s, e) =>
             {
@@ -26,11 +26,11 @@ namespace LudusaviRestic
                 {
                     if (ResticPasswordBox != null)
                     {
-                        ResticPasswordBox.Password = this.plugin.settings.ResticPassword ?? string.Empty;
+                        ResticPasswordBox.Password = this._plugin.settings.ResticPassword ?? string.Empty;
                     }
                     if (RclonePasswordBox != null)
                     {
-                        RclonePasswordBox.Password = this.plugin.settings.RcloneConfigPassword ?? string.Empty;
+                        RclonePasswordBox.Password = this._plugin.settings.RcloneConfigPassword ?? string.Empty;
                     }
                     if (OverridesDataGrid != null)
                     {
@@ -53,11 +53,11 @@ namespace LudusaviRestic
 
         public void OnBrowseLudusaviExecutablePath(object sender, RoutedEventArgs e)
         {
-            var choice = this.plugin.PlayniteApi.Dialogs.SelectFile(this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestExecutableFilterShort"));
+            var choice = this._plugin.PlayniteApi.Dialogs.SelectFile(this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestExecutableFilterShort"));
 
             if (choice.Length > 0)
             {
-                this.plugin.settings.LudusaviExecutablePath = choice;
+                this._plugin.settings.LudusaviExecutablePath = choice;
             }
         }
 
@@ -66,22 +66,22 @@ namespace LudusaviRestic
             var detectedPath = ResticUtility.DetectLudusaviExecutable();
             if (!string.IsNullOrWhiteSpace(detectedPath))
             {
-                this.plugin.settings.LudusaviExecutablePath = detectedPath;
-                this.plugin.PlayniteApi.Dialogs.ShowMessage(string.Format(this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsLudusaviDetected"), detectedPath), this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsAutoDetectSuccess"));
+                this._plugin.settings.LudusaviExecutablePath = detectedPath;
+                this._plugin.PlayniteApi.Dialogs.ShowMessage(string.Format(this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsLudusaviDetected"), detectedPath), this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsAutoDetectSuccess"));
             }
             else
             {
-                this.plugin.PlayniteApi.Dialogs.ShowMessage(this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsLudusaviNotDetected"), this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsAutoDetectFailed"));
+                this._plugin.PlayniteApi.Dialogs.ShowMessage(this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsLudusaviNotDetected"), this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsAutoDetectFailed"));
             }
         }
 
         public void OnBrowseResticExecutablePath(object sender, RoutedEventArgs e)
         {
-            var choice = this.plugin.PlayniteApi.Dialogs.SelectFile(this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestExecutableFilterShort"));
+            var choice = this._plugin.PlayniteApi.Dialogs.SelectFile(this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestExecutableFilterShort"));
 
             if (choice.Length > 0)
             {
-                this.plugin.settings.ResticExecutablePath = choice;
+                this._plugin.settings.ResticExecutablePath = choice;
             }
         }
 
@@ -90,22 +90,22 @@ namespace LudusaviRestic
             var detectedPath = ResticUtility.DetectResticExecutable();
             if (!string.IsNullOrWhiteSpace(detectedPath))
             {
-                this.plugin.settings.ResticExecutablePath = detectedPath;
-                this.plugin.PlayniteApi.Dialogs.ShowMessage(string.Format(this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsResticDetected"), detectedPath), this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsAutoDetectSuccess"));
+                this._plugin.settings.ResticExecutablePath = detectedPath;
+                this._plugin.PlayniteApi.Dialogs.ShowMessage(string.Format(this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsResticDetected"), detectedPath), this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsAutoDetectSuccess"));
             }
             else
             {
-                this.plugin.PlayniteApi.Dialogs.ShowMessage(this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsResticNotDetected"), this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsAutoDetectFailed"));
+                this._plugin.PlayniteApi.Dialogs.ShowMessage(this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsResticNotDetected"), this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestSettingsAutoDetectFailed"));
             }
         }
 
         public void OnBrowseRcloneConfPath(object sender, RoutedEventArgs e)
         {
-            var choice = this.plugin.PlayniteApi.Dialogs.SelectFile(this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestConfigFilter"));
+            var choice = this._plugin.PlayniteApi.Dialogs.SelectFile(this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestConfigFilter"));
 
             if (choice.Length > 0)
             {
-                this.plugin.settings.RcloneConfigPath = choice;
+                this._plugin.settings.RcloneConfigPath = choice;
             }
         }
 
@@ -163,16 +163,16 @@ namespace LudusaviRestic
 
         private void PopulateSourcesList()
         {
-            var sources = this.plugin.PlayniteApi.Database.Sources
+            var sources = this._plugin.PlayniteApi.Database.Sources
                 .OrderBy(s => s.Name)
-                .Select(s => new SourceCheckItem(s.Name, s.Id, this.plugin.settings.ExcludedSourceIds))
+                .Select(s => new SourceCheckItem(s.Name, s.Id, this._plugin.settings.ExcludedSourceIds))
                 .ToList();
             ExcludedSourcesList.ItemsSource = sources;
         }
 
         private void RefreshOverridesGrid()
         {
-            var items = this.plugin.settings.GameIntervalOverrides.Select(kvp =>
+            var items = this._plugin.settings.GameIntervalOverrides.Select(kvp =>
             {
                 var item = kvp.Value;
                 item.GameId = kvp.Key;
@@ -185,7 +185,7 @@ namespace LudusaviRestic
         {
             if (OverridesDataGrid.SelectedItem is GameOverride selected && selected.GameId != null)
             {
-                this.plugin.settings.GameIntervalOverrides.Remove(selected.GameId);
+                this._plugin.settings.GameIntervalOverrides.Remove(selected.GameId);
                 RefreshOverridesGrid();
             }
         }
@@ -198,7 +198,7 @@ namespace LudusaviRestic
                 if (textBox == null) return;
 
                 int columnIndex = e.Column.DisplayIndex;
-                var target = this.plugin.settings.GameIntervalOverrides[item.GameId];
+                var target = this._plugin.settings.GameIntervalOverrides[item.GameId];
 
                 if (columnIndex == 1) // IntervalMinutes (nullable)
                 {
@@ -254,8 +254,8 @@ namespace LudusaviRestic
 
         public void OnVerify(object sender, RoutedEventArgs e)
         {
-            BackupContext context = new BackupContext(this.plugin.PlayniteApi, this.plugin.settings);
-            var api = this.plugin.PlayniteApi;
+            BackupContext context = new BackupContext(this._plugin.PlayniteApi, this._plugin.settings);
+            var api = this._plugin.PlayniteApi;
             var resources = api.Resources;
             string title = resources.GetString("LOCLuduRestSettingsVerificationTitle");
             string verifyingRestic = resources.GetString("LOCLuduRestVerifyingRestic");
@@ -305,12 +305,12 @@ namespace LudusaviRestic
 
         private void SyncResticPasswordToSettings(string value)
         {
-            this.plugin.settings.ResticPassword = value;
+            this._plugin.settings.ResticPassword = value;
         }
 
         private void SyncRclonePasswordToSettings(string value)
         {
-            this.plugin.settings.RcloneConfigPassword = value;
+            this._plugin.settings.RcloneConfigPassword = value;
         }
 
         public void OnResticPasswordChanged(object sender, RoutedEventArgs e)
@@ -355,7 +355,7 @@ namespace LudusaviRestic
                     ResticPasswordText.Text = ResticPasswordBox.Password;
                     ResticPasswordBox.Visibility = Visibility.Collapsed;
                     ResticPasswordText.Visibility = Visibility.Visible;
-                    ResticPasswordToggle.Content = this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestHide");
+                    ResticPasswordToggle.Content = this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestHide");
                 }
                 else
                 {
@@ -363,7 +363,7 @@ namespace LudusaviRestic
                     ResticPasswordBox.Password = ResticPasswordText.Text;
                     ResticPasswordText.Visibility = Visibility.Collapsed;
                     ResticPasswordBox.Visibility = Visibility.Visible;
-                    ResticPasswordToggle.Content = this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestShow");
+                    ResticPasswordToggle.Content = this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestShow");
                 }
             }
             catch (Exception ex)
@@ -381,14 +381,14 @@ namespace LudusaviRestic
                     RclonePasswordText.Text = RclonePasswordBox.Password;
                     RclonePasswordBox.Visibility = Visibility.Collapsed;
                     RclonePasswordText.Visibility = Visibility.Visible;
-                    RclonePasswordToggle.Content = this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestHide");
+                    RclonePasswordToggle.Content = this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestHide");
                 }
                 else
                 {
                     RclonePasswordBox.Password = RclonePasswordText.Text;
                     RclonePasswordText.Visibility = Visibility.Collapsed;
                     RclonePasswordBox.Visibility = Visibility.Visible;
-                    RclonePasswordToggle.Content = this.plugin.PlayniteApi.Resources.GetString("LOCLuduRestShow");
+                    RclonePasswordToggle.Content = this._plugin.PlayniteApi.Resources.GetString("LOCLuduRestShow");
                 }
             }
             catch (Exception ex)
@@ -400,18 +400,18 @@ namespace LudusaviRestic
 
     public class SourceCheckItem : INotifyPropertyChanged
     {
-        private readonly List<Guid> excludedList;
+        private readonly List<Guid> _excludedList;
 
         public string Name { get; }
         public Guid SourceId { get; }
 
         public bool IsExcluded
         {
-            get => excludedList.Contains(SourceId);
+            get => _excludedList.Contains(SourceId);
             set
             {
-                if (value) { if (!excludedList.Contains(SourceId)) excludedList.Add(SourceId); }
-                else { excludedList.Remove(SourceId); }
+                if (value) { if (!_excludedList.Contains(SourceId)) _excludedList.Add(SourceId); }
+                else { _excludedList.Remove(SourceId); }
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExcluded)));
             }
         }
@@ -422,7 +422,7 @@ namespace LudusaviRestic
         {
             Name = name;
             SourceId = sourceId;
-            this.excludedList = excludedList;
+            this._excludedList = excludedList;
         }
     }
 }

--- a/src/Views/LudusaviResticSettingsView.xaml.cs
+++ b/src/Views/LudusaviResticSettingsView.xaml.cs
@@ -398,7 +398,7 @@ namespace LudusaviRestic
         }
     }
 
-    public class SourceCheckItem : INotifyPropertyChanged
+    internal class SourceCheckItem : INotifyPropertyChanged
     {
         private readonly List<Guid> _excludedList;
 

--- a/src/Views/PruneResultsWindow.xaml.cs
+++ b/src/Views/PruneResultsWindow.xaml.cs
@@ -10,14 +10,14 @@ namespace LudusaviRestic
 {
     public partial class PruneResultsWindow : Window
     {
-        private PruneResult pruneResult;
-        private ObservableCollection<DeletedSnapshotViewModel> allSnapshots;
-        private ObservableCollection<DeletedSnapshotViewModel> filteredSnapshots;
+        private PruneResult _pruneResult;
+        private ObservableCollection<DeletedSnapshotViewModel> _allSnapshots;
+        private ObservableCollection<DeletedSnapshotViewModel> _filteredSnapshots;
 
         public PruneResultsWindow(PruneResult result)
         {
             InitializeComponent();
-            this.pruneResult = result;
+            this._pruneResult = result;
             ApplyPlayniteTheme();
             InitializeData();
         }
@@ -44,48 +44,48 @@ namespace LudusaviRestic
         private void InitializeData()
         {
             // Set title based on operation type
-            TitleText.Text = pruneResult.IsDryRun ? "Pruning Preview (Dry Run)" : "Pruning Results";
+            TitleText.Text = _pruneResult.IsDryRun ? "Pruning Preview (Dry Run)" : "Pruning Results";
 
             // Set summary text
-            var operationType = pruneResult.IsDryRun ? "would be" : "were";
+            var operationType = _pruneResult.IsDryRun ? "would be" : "were";
             SummaryText.Text = $"The following snapshots {operationType} deleted from the repository.";
 
             // Update statistics
-            SnapshotsDeletedText.Text = pruneResult.SnapshotsDeleted.ToString();
-            GamesAffectedText.Text = pruneResult.GamesAffected.ToString();
-            DataDeletedText.Text = string.IsNullOrEmpty(pruneResult.DataDeleted) ? "N/A" : pruneResult.DataDeleted;
-            StatusText.Text = pruneResult.Success ? "Success" : "Failed";
-            StatusText.Foreground = pruneResult.Success ?
+            SnapshotsDeletedText.Text = _pruneResult.SnapshotsDeleted.ToString();
+            GamesAffectedText.Text = _pruneResult.GamesAffected.ToString();
+            DataDeletedText.Text = string.IsNullOrEmpty(_pruneResult.DataDeleted) ? "N/A" : _pruneResult.DataDeleted;
+            StatusText.Text = _pruneResult.Success ? "Success" : "Failed";
+            StatusText.Foreground = _pruneResult.Success ?
                 System.Windows.Media.Brushes.Green :
                 System.Windows.Media.Brushes.Red;
 
             // Convert snapshots to view models
-            allSnapshots = new ObservableCollection<DeletedSnapshotViewModel>(
-                pruneResult.DeletedSnapshots.Select(s => new DeletedSnapshotViewModel(s))
+            _allSnapshots = new ObservableCollection<DeletedSnapshotViewModel>(
+                _pruneResult.DeletedSnapshots.Select(s => new DeletedSnapshotViewModel(s))
             );
-            filteredSnapshots = new ObservableCollection<DeletedSnapshotViewModel>(allSnapshots);
+            _filteredSnapshots = new ObservableCollection<DeletedSnapshotViewModel>(_allSnapshots);
 
             // Set up data grids
-            SnapshotsDataGrid.ItemsSource = filteredSnapshots;
+            SnapshotsDataGrid.ItemsSource = _filteredSnapshots;
 
             // Games summary
-            var gamesSummary = pruneResult.GetGameDeletionCounts()
+            var gamesSummary = _pruneResult.GetGameDeletionCounts()
                 .OrderByDescending(kvp => kvp.Value)
                 .ThenBy(kvp => kvp.Key);
             GamesSummaryDataGrid.ItemsSource = gamesSummary;
 
             // Tags summary
-            var tagsSummary = pruneResult.GetTagDeletionCounts()
+            var tagsSummary = _pruneResult.GetTagDeletionCounts()
                 .OrderByDescending(kvp => kvp.Value)
                 .ThenBy(kvp => kvp.Key);
             TagsSummaryDataGrid.ItemsSource = tagsSummary;
 
             // Raw output
-            RawOutputTextBox.Text = pruneResult.RawOutput;
+            RawOutputTextBox.Text = _pruneResult.RawOutput;
 
             // Set up game filter
             var gameNames = new List<string> { "All Games" };
-            gameNames.AddRange(pruneResult.DeletedSnapshots
+            gameNames.AddRange(_pruneResult.DeletedSnapshots
                 .Where(s => !string.IsNullOrEmpty(s.GameName))
                 .Select(s => s.GameName)
                 .Distinct()
@@ -110,18 +110,18 @@ namespace LudusaviRestic
 
             if (string.IsNullOrEmpty(selectedGame) || selectedGame == "All Games")
             {
-                filteredSnapshots.Clear();
-                foreach (var snapshot in allSnapshots)
+                _filteredSnapshots.Clear();
+                foreach (var snapshot in _allSnapshots)
                 {
-                    filteredSnapshots.Add(snapshot);
+                    _filteredSnapshots.Add(snapshot);
                 }
             }
             else
             {
-                filteredSnapshots.Clear();
-                foreach (var snapshot in allSnapshots.Where(s => s.GameName == selectedGame))
+                _filteredSnapshots.Clear();
+                foreach (var snapshot in _allSnapshots.Where(s => s.GameName == selectedGame))
                 {
-                    filteredSnapshots.Add(snapshot);
+                    _filteredSnapshots.Add(snapshot);
                 }
             }
         }
@@ -132,21 +132,21 @@ namespace LudusaviRestic
         }
     }
 
-    public class DeletedSnapshotViewModel
+    internal class DeletedSnapshotViewModel
     {
-        private readonly DeletedSnapshot snapshot;
+        private readonly DeletedSnapshot _snapshot;
 
         public DeletedSnapshotViewModel(DeletedSnapshot snapshot)
         {
-            this.snapshot = snapshot;
+            this._snapshot = snapshot;
         }
 
-        public string ShortId => snapshot.ShortId;
-        public string GameName => string.IsNullOrEmpty(snapshot.GameName) ? "Unknown" : snapshot.GameName;
-        public DateTime Time => snapshot.Time;
-        public string TagsString => string.Join(", ", snapshot.Tags);
-        public List<string> Tags => snapshot.Tags;
-        public string Host => snapshot.Host;
-        public List<string> Paths => snapshot.Paths;
+        public string ShortId => _snapshot.ShortId;
+        public string GameName => string.IsNullOrEmpty(_snapshot.GameName) ? "Unknown" : _snapshot.GameName;
+        public DateTime Time => _snapshot.Time;
+        public string TagsString => string.Join(", ", _snapshot.Tags);
+        public List<string> Tags => _snapshot.Tags;
+        public string Host => _snapshot.Host;
+        public List<string> Paths => _snapshot.Paths;
     }
 }

--- a/src/Views/SetupWizardWindow.xaml.cs
+++ b/src/Views/SetupWizardWindow.xaml.cs
@@ -11,8 +11,8 @@ namespace LudusaviRestic
     public partial class SetupWizardWindow : Window
     {
         private static readonly ILogger logger = LogManager.GetLogger();
-        private BackupContext context;
-        private int currentStep = 0;
+        private BackupContext _context;
+        private int _currentStep = 0;
         private const int TotalSteps = 3;
 
         public LudusaviResticSettings ResultSettings { get; private set; }
@@ -21,8 +21,8 @@ namespace LudusaviRestic
         public SetupWizardWindow(BackupContext context)
         {
             InitializeComponent();
-            this.context = context;
-            ApplyPlayniteTheme(context.API);
+            this._context = context;
+            ApplyPlayniteTheme(_context.API);
             InitializeWizard();
         }
 
@@ -71,12 +71,12 @@ namespace LudusaviRestic
             if (!string.IsNullOrWhiteSpace(detectedPath))
             {
                 ResticPathTextBox.Text = detectedPath;
-                ResticStatusText.Text = context.API.Resources.GetString("LOCLuduRestSetupResticFoundVerified");
+                ResticStatusText.Text = _context.API.Resources.GetString("LOCLuduRestSetupResticFoundVerified");
                 ResticStatusText.Foreground = System.Windows.Media.Brushes.Green;
             }
             else
             {
-                ResticStatusText.Text = context.API.Resources.GetString("LOCLuduRestSetupResticNotFound");
+                ResticStatusText.Text = _context.API.Resources.GetString("LOCLuduRestSetupResticNotFound");
                 ResticStatusText.Foreground = System.Windows.Media.Brushes.Orange;
             }
         }
@@ -87,12 +87,12 @@ namespace LudusaviRestic
             if (!string.IsNullOrWhiteSpace(detectedPath))
             {
                 LudusaviPathTextBox.Text = detectedPath;
-                LudusaviStatusText.Text = context.API.Resources.GetString("LOCLuduRestSetupLudusaviFoundVerified");
+                LudusaviStatusText.Text = _context.API.Resources.GetString("LOCLuduRestSetupLudusaviFoundVerified");
                 LudusaviStatusText.Foreground = System.Windows.Media.Brushes.Green;
             }
             else
             {
-                LudusaviStatusText.Text = context.API.Resources.GetString("LOCLuduRestSetupLudusaviNotFound");
+                LudusaviStatusText.Text = _context.API.Resources.GetString("LOCLuduRestSetupLudusaviNotFound");
                 LudusaviStatusText.Foreground = System.Windows.Media.Brushes.Orange;
             }
         }
@@ -106,8 +106,8 @@ namespace LudusaviRestic
         {
             var dialog = new OpenFileDialog
             {
-                Title = context.API.Resources.GetString("LOCLuduRestSelectResticExecutable"),
-                Filter = context.API.Resources.GetString("LOCLuduRestExecutableFilter"),
+                Title = _context.API.Resources.GetString("LOCLuduRestSelectResticExecutable"),
+                Filter = _context.API.Resources.GetString("LOCLuduRestExecutableFilter"),
                 CheckFileExists = true
             };
 
@@ -123,19 +123,19 @@ namespace LudusaviRestic
             var path = ResticPathTextBox.Text.Trim();
             if (string.IsNullOrWhiteSpace(path))
             {
-                ResticStatusText.Text = context.API.Resources.GetString("LOCLuduRestPleaseSpecifyResticPath");
+                ResticStatusText.Text = _context.API.Resources.GetString("LOCLuduRestPleaseSpecifyResticPath");
                 ResticStatusText.Foreground = System.Windows.Media.Brushes.Red;
                 return;
             }
 
             if (ResticUtility.IsValidResticExecutable(path))
             {
-                ResticStatusText.Text = context.API.Resources.GetString("LOCLuduRestValidResticExecutable");
+                ResticStatusText.Text = _context.API.Resources.GetString("LOCLuduRestValidResticExecutable");
                 ResticStatusText.Foreground = System.Windows.Media.Brushes.Green;
             }
             else
             {
-                ResticStatusText.Text = context.API.Resources.GetString("LOCLuduRestInvalidResticExecutable");
+                ResticStatusText.Text = _context.API.Resources.GetString("LOCLuduRestInvalidResticExecutable");
                 ResticStatusText.Foreground = System.Windows.Media.Brushes.Red;
             }
         }
@@ -154,8 +154,8 @@ namespace LudusaviRestic
         {
             var dialog = new OpenFileDialog
             {
-                Title = context.API.Resources.GetString("LOCLuduRestSelectLudusaviExecutable"),
-                Filter = context.API.Resources.GetString("LOCLuduRestExecutableFilter"),
+                Title = _context.API.Resources.GetString("LOCLuduRestSelectLudusaviExecutable"),
+                Filter = _context.API.Resources.GetString("LOCLuduRestExecutableFilter"),
                 CheckFileExists = true
             };
 
@@ -171,19 +171,19 @@ namespace LudusaviRestic
             var path = LudusaviPathTextBox.Text.Trim();
             if (string.IsNullOrWhiteSpace(path))
             {
-                LudusaviStatusText.Text = context.API.Resources.GetString("LOCLuduRestPleaseSpecifyLudusaviPath");
+                LudusaviStatusText.Text = _context.API.Resources.GetString("LOCLuduRestPleaseSpecifyLudusaviPath");
                 LudusaviStatusText.Foreground = System.Windows.Media.Brushes.Red;
                 return;
             }
 
             if (ResticUtility.IsValidLudusaviExecutable(path))
             {
-                LudusaviStatusText.Text = context.API.Resources.GetString("LOCLuduRestValidLudusaviExecutable");
+                LudusaviStatusText.Text = _context.API.Resources.GetString("LOCLuduRestValidLudusaviExecutable");
                 LudusaviStatusText.Foreground = System.Windows.Media.Brushes.Green;
             }
             else
             {
-                LudusaviStatusText.Text = context.API.Resources.GetString("LOCLuduRestInvalidLudusaviExecutable");
+                LudusaviStatusText.Text = _context.API.Resources.GetString("LOCLuduRestInvalidLudusaviExecutable");
                 LudusaviStatusText.Foreground = System.Windows.Media.Brushes.Red;
             }
         }
@@ -197,7 +197,7 @@ namespace LudusaviRestic
         {
             var dialog = new System.Windows.Forms.FolderBrowserDialog
             {
-                Description = context.API.Resources.GetString("LOCLuduRestSelectRepositoryLocation"),
+                Description = _context.API.Resources.GetString("LOCLuduRestSelectRepositoryLocation"),
                 ShowNewFolderButton = true
             };
 
@@ -217,10 +217,10 @@ namespace LudusaviRestic
 
         private void Previous_Click(object sender, RoutedEventArgs e)
         {
-            if (currentStep > 0)
+            if (_currentStep > 0)
             {
-                currentStep--;
-                WizardTabs.SelectedIndex = currentStep;
+                _currentStep--;
+                WizardTabs.SelectedIndex = _currentStep;
                 UpdateNavigationButtons();
             }
         }
@@ -229,13 +229,13 @@ namespace LudusaviRestic
         {
             if (ValidateCurrentStep())
             {
-                if (currentStep < TotalSteps - 1)
+                if (_currentStep < TotalSteps - 1)
                 {
-                    currentStep++;
-                    WizardTabs.SelectedIndex = currentStep;
+                    _currentStep++;
+                    WizardTabs.SelectedIndex = _currentStep;
                     UpdateNavigationButtons();
 
-                    if (currentStep == 2) // Summary step
+                    if (_currentStep == 2) // Summary step
                     {
                         UpdateSummary();
                     }
@@ -245,19 +245,19 @@ namespace LudusaviRestic
 
         private bool ValidateCurrentStep()
         {
-            switch (currentStep)
+            switch (_currentStep)
             {
                 case 0: // Restic executable
                     var resticPath = ResticPathTextBox.Text.Trim();
                     if (string.IsNullOrWhiteSpace(resticPath))
                     {
-                        MessageBox.Show(context.API.Resources.GetString("LOCLuduRestValidationResticPath"), context.API.Resources.GetString("LOCLuduRestValidationError"),
+                        MessageBox.Show(_context.API.Resources.GetString("LOCLuduRestValidationResticPath"), _context.API.Resources.GetString("LOCLuduRestValidationError"),
                                       MessageBoxButton.OK, MessageBoxImage.Warning);
                         return false;
                     }
                     if (!ResticUtility.IsValidResticExecutable(resticPath))
                     {
-                        MessageBox.Show(context.API.Resources.GetString("LOCLuduRestValidationResticInvalid"), context.API.Resources.GetString("LOCLuduRestValidationError"),
+                        MessageBox.Show(_context.API.Resources.GetString("LOCLuduRestValidationResticInvalid"), _context.API.Resources.GetString("LOCLuduRestValidationError"),
                                       MessageBoxButton.OK, MessageBoxImage.Warning);
                         return false;
                     }
@@ -267,7 +267,7 @@ namespace LudusaviRestic
                     var repoPath = RepositoryPathTextBox.Text.Trim();
                     if (string.IsNullOrWhiteSpace(repoPath))
                     {
-                        MessageBox.Show(context.API.Resources.GetString("LOCLuduRestValidationRepositoryPath"), context.API.Resources.GetString("LOCLuduRestValidationError"),
+                        MessageBox.Show(_context.API.Resources.GetString("LOCLuduRestValidationRepositoryPath"), _context.API.Resources.GetString("LOCLuduRestValidationError"),
                                       MessageBoxButton.OK, MessageBoxImage.Warning);
                         return false;
                     }
@@ -277,14 +277,14 @@ namespace LudusaviRestic
 
                     if (string.IsNullOrWhiteSpace(password))
                     {
-                        MessageBox.Show(context.API.Resources.GetString("LOCLuduRestValidationRepositoryPassword"), context.API.Resources.GetString("LOCLuduRestValidationError"),
+                        MessageBox.Show(_context.API.Resources.GetString("LOCLuduRestValidationRepositoryPassword"), _context.API.Resources.GetString("LOCLuduRestValidationError"),
                                       MessageBoxButton.OK, MessageBoxImage.Warning);
                         return false;
                     }
 
                     if (password != confirmPassword)
                     {
-                        MessageBox.Show(context.API.Resources.GetString("LOCLuduRestValidationPasswordMismatch"), context.API.Resources.GetString("LOCLuduRestValidationError"),
+                        MessageBox.Show(_context.API.Resources.GetString("LOCLuduRestValidationPasswordMismatch"), _context.API.Resources.GetString("LOCLuduRestValidationError"),
                                       MessageBoxButton.OK, MessageBoxImage.Warning);
                         return false;
                     }
@@ -301,21 +301,21 @@ namespace LudusaviRestic
             SummaryResticPath.Text = ResticPathTextBox.Text;
             SummaryRepositoryPath.Text = RepositoryPathTextBox.Text;
             SummaryPasswordStatus.Text = string.IsNullOrWhiteSpace(RepositoryPasswordBox.Password) ?
-                context.API.Resources.GetString("LOCLuduRestSummaryNo") : context.API.Resources.GetString("LOCLuduRestSummaryYes");
+                _context.API.Resources.GetString("LOCLuduRestSummaryNo") : _context.API.Resources.GetString("LOCLuduRestSummaryYes");
             SummaryInitStatus.Text = CreateNewRepositoryCheckBox.IsChecked == true ?
-                context.API.Resources.GetString("LOCLuduRestSummaryYes") : context.API.Resources.GetString("LOCLuduRestSummaryNo");
+                _context.API.Resources.GetString("LOCLuduRestSummaryYes") : _context.API.Resources.GetString("LOCLuduRestSummaryNo");
         }
 
         private void UpdateNavigationButtons()
         {
-            PreviousButton.IsEnabled = currentStep > 0;
-            NextButton.Visibility = currentStep < TotalSteps - 1 ? Visibility.Visible : Visibility.Collapsed;
-            FinishButton.Visibility = currentStep == TotalSteps - 1 ? Visibility.Visible : Visibility.Collapsed;
+            PreviousButton.IsEnabled = _currentStep > 0;
+            NextButton.Visibility = _currentStep < TotalSteps - 1 ? Visibility.Visible : Visibility.Collapsed;
+            FinishButton.Visibility = _currentStep == TotalSteps - 1 ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void WizardTabs_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            currentStep = WizardTabs.SelectedIndex;
+            _currentStep = WizardTabs.SelectedIndex;
             UpdateNavigationButtons();
         }
 
@@ -335,16 +335,16 @@ namespace LudusaviRestic
                 // Initialize repository if requested
                 if (CreateNewRepositoryCheckBox.IsChecked == true)
                 {
-                    var tempContext = new BackupContext(context.API, ResultSettings);
+                    var tempContext = new BackupContext(_context.API, ResultSettings);
 
                     // Show progress
-                    var progressOptions = new GlobalProgressOptions(context.API.Resources.GetString("LOCLuduRestInitializingRepository"), true)
+                    var progressOptions = new GlobalProgressOptions(_context.API.Resources.GetString("LOCLuduRestInitializingRepository"), true)
                     {
                         IsIndeterminate = true
                     };
 
                     bool initSuccess = false;
-                    context.API.Dialogs.ActivateGlobalProgress((progress) =>
+                    _context.API.Dialogs.ActivateGlobalProgress((progress) =>
                     {
                         try
                         {
@@ -369,8 +369,8 @@ namespace LudusaviRestic
 
                     if (!initSuccess)
                     {
-                        MessageBox.Show(context.API.Resources.GetString("LOCLuduRestInitializationFailed"),
-                                      context.API.Resources.GetString("LOCLuduRestInitializationError"), MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(_context.API.Resources.GetString("LOCLuduRestInitializationFailed"),
+                                      _context.API.Resources.GetString("LOCLuduRestInitializationError"), MessageBoxButton.OK, MessageBoxImage.Error);
                         return;
                     }
                 }
@@ -382,7 +382,7 @@ namespace LudusaviRestic
             catch (Exception ex)
             {
                 logger.Error(ex, "Error during setup completion");
-                MessageBox.Show(string.Format(context.API.Resources.GetString("LOCLuduRestSetupErrorMessage"), ex.Message), context.API.Resources.GetString("LOCLuduRestSetupError"),
+                MessageBox.Show(string.Format(_context.API.Resources.GetString("LOCLuduRestSetupErrorMessage"), ex.Message), _context.API.Resources.GetString("LOCLuduRestSetupError"),
                               MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }


### PR DESCRIPTION
## Summary

Audit of the codebase against the new CLAUDE.md guidelines (§5 C# Conventions, §6 Playnite Plugin Rules) found violations in five categories. This PR fixes all of them.

- **Logging**: Replace 3× `Debug.WriteLine` with `logger.Debug`/`logger.Error` in `PruneResult.cs`; add missing log to silent catch block
- **Lifecycle**: Add `OnApplicationStopped` override to `LudusaviRestic.cs` to dispose the gameplay backup timer on shutdown
- **Resource management**: Wrap 4 `Process` objects in `using` blocks (`ResticUtility.cs`); replace `.Flush()/.Close()` on `StreamWriter` with a `using` block (`BaseBackupTask.cs`)
- **Access modifiers**: Narrow `RelayCommand`, `DeletedSnapshotViewModel`, and `PruneResultParser` from `public` to `internal`
- **Private field naming**: Rename ~45 private fields across 12 files to `_camelCase` convention

## Test plan

- [x] All 165 unit tests pass (`task test`)
- [x] Code reviewed by parallel subagents — two additional missed fields (`DeletedSnapshotViewModel._snapshot`, `SourceCheckItem._excludedList`) caught and fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)