### PR TITLE
Fix security, data-loss and reliability defects from July 2026 audit (v1.3.1)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,4 +32,3 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}'
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
       - id: format
         name: format
         language: system
-        entry: dotnet format src
+        entry: dotnet format src/LudusaviRestic.csproj
         types: [c#]
         pass_filenames: false

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,7 +1,7 @@
 Id: LudusaviRestic_e9861c36-68a8-4654-8071-a9c50612bc24
 Name: Ludusavi Restic
 Author: sharkusmanch
-Version: 1.3.0
+Version: 1.3.1
 Module: LudusaviRestic.dll
 Type: GenericPlugin
 Icon: icon.png

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,18 @@
 AddonId: LudusaviRestic_e9861c36-68a8-4654-8071-a9c50612bc24
 Packages:
+  - Version: 1.3.1
+    RequiredApiVersion: 6.14.0
+    ReleaseDate: 2026-07-26
+    PackageUrl: https://github.com/sharkusmanch/playnite-ludusavi-restic/releases/download/v1.3.1/LudusaviRestic_v1.3.1.pext
+    Changelog:
+      - 'Security: the restic repository password is no longer written into Playnite''s process environment, where every launched game, launcher and emulator inherited it. Credentials are now passed per-invocation.'
+      - 'Fix: answering No to "Proceed with pruning?" during full maintenance no longer prunes the repository anyway'
+      - 'Fix: restic failures (missing repository, locked repository, wrong password) are no longer reported as successful snapshots'
+      - 'Fix: backups no longer deadlock when restic writes more than 4 KB to stderr, which previously blocked every subsequent backup for the session'
+      - 'Fix: gameplay backup timers are tracked per game, so starting a second game no longer leaves the first game backing up for the rest of the session'
+      - 'Fix: adding a backup tag to a game with no existing tags is now persisted instead of being lost on restart'
+      - 'Fix: repository initialization no longer clears the rclone configuration for the session'
+      - 'Fix: temporary file lists are no longer leaked when a backup fails'
   - Version: 1.3.0
     RequiredApiVersion: 6.14.0
     ReleaseDate: 2026-04-13

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,21 @@
   "extends": [
     "config:recommended"
   ],
-  "ignoreDeps": [
-    "Newtonsoft.Json"
+  "packageRules": [
+    {
+      "description": "Pinned to 10.0.3 deliberately: Playnite loads its own Newtonsoft.Json into the plugin AppDomain, and referencing a different version causes assembly load failures at runtime. Those surface as silently swallowed exceptions inside try/catch blocks rather than build errors, so an upgrade here looks green and fails in production. The test project pins the same version plus a binding redirect for the same reason.",
+      "matchPackageNames": [
+        "Newtonsoft.Json"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "xunit v3 dropped .NET Framework 4.6.2 and requires net472 or later; this project targets net462. Upgrades fail restore with NU1202 rather than producing a usable build, so hold at 2.x. Minor and patch updates within 2.x are still proposed.",
+      "matchPackageNames": [
+        "xunit",
+        "xunit.runner.visualstudio"
+      ],
+      "allowedVersions": "<3"
+    }
   ]
 }

--- a/src/Commands/BaseCommand.cs
+++ b/src/Commands/BaseCommand.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 using Playnite.SDK;
 
 namespace LudusaviRestic
@@ -9,19 +11,48 @@ namespace LudusaviRestic
 
         protected static CommandResult ExecuteCommand(string command, string args)
         {
-            Process process = new Process();
-            process.StartInfo.FileName = command;
-            process.StartInfo.Arguments = args;
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            process.StartInfo.CreateNoWindow = true;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.StartInfo.RedirectStandardError = true;
+            return ExecuteCommand(command, args, null);
+        }
 
-            logger.Debug(process.StartInfo.FileName);
-            logger.Debug(process.StartInfo.Arguments);
+        // internal rather than protected so ResticUtility can reuse it: a second
+        // process-launch path is how the pipe-deadlock and encoding bugs got duplicated.
+        internal static CommandResult ExecuteCommand(string command, string args, IDictionary<string, string> environment)
+        {
+            return ExecuteCommand(command, args, environment, CommandResult.DefaultTimeoutMilliseconds);
+        }
 
-            return new CommandResult(process);
+        internal static CommandResult ExecuteCommand(string command, string args,
+            IDictionary<string, string> environment, int timeoutMilliseconds)
+        {
+            using (Process process = new Process())
+            {
+                process.StartInfo.FileName = command;
+                process.StartInfo.Arguments = args;
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                process.StartInfo.CreateNoWindow = true;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.StartInfo.RedirectStandardInput = true;
+
+                // restic and ludusavi emit UTF-8. Without this the streams are decoded
+                // using the console code page, which mangles any non-ASCII game name.
+                process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+                process.StartInfo.StandardErrorEncoding = Encoding.UTF8;
+
+                if (environment != null)
+                {
+                    foreach (var variable in environment)
+                    {
+                        process.StartInfo.Environment[variable.Key] = variable.Value;
+                    }
+                }
+
+                logger.Debug(process.StartInfo.FileName);
+                logger.Debug(process.StartInfo.Arguments);
+
+                return new CommandResult(process, timeoutMilliseconds);
+            }
         }
     }
 }

--- a/src/Commands/ResticCommand.cs
+++ b/src/Commands/ResticCommand.cs
@@ -187,7 +187,7 @@ namespace LudusaviRestic
         private static CommandResult ResticExecute(BackupContext context, string args)
         {
             string command = context.Settings.ResticExecutablePath.Trim();
-            return ExecuteCommand(command, args);
+            return ExecuteCommand(command, args, context.BuildResticEnvironment());
         }
     }
 }

--- a/src/LudusaviRestic.cs
+++ b/src/LudusaviRestic.cs
@@ -20,7 +20,12 @@ namespace LudusaviRestic
         public override Guid Id { get; } = Guid.Parse("e9861c36-68a8-4654-8071-a9c50612bc24");
 
         private ResticBackupManager _manager;
-        private Timer _timer;
+
+        // Keyed by Game.Id: Playnite can have several games running at once, and a single
+        // field left the previous game's timer running — and its Game pinned — for the
+        // rest of the session.
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<Guid, Timer> _timers =
+            new System.Collections.Concurrent.ConcurrentDictionary<Guid, Timer>();
 
         public LudusaviRestic(IPlayniteAPI api) : base(api)
         {
@@ -383,7 +388,11 @@ namespace LudusaviRestic
                 }
                 else
                 {
+                    // Only reachable when TagIds is null, so assigning a fresh list drops
+                    // nothing. This branch mutates the game, so it must report true or the
+                    // caller skips Games.Update and the tag is lost on restart.
                     game.TagIds = new List<Guid> { tagId };
+                    return true;
                 }
             }
             return false;
@@ -449,17 +458,17 @@ namespace LudusaviRestic
                             var dryRunWindow = new PruneResultsWindow(parsedDryRun);
                             dryRunWindow.Owner = PlayniteApi.Dialogs.GetCurrentAppWindow();
                             dryRunWindow.ShowDialog();
-
-                            // Ask if user wants to proceed
-                            var proceedResult = PlayniteApi.Dialogs.ShowMessage(
-                                string.Format(GetLocalizedString("LOCLuduRestDryRunCompletedMessage", "LOCLuduRestDryRunCompletedMessage"), parsedDryRun.SnapshotsDeleted),
-                                GetLocalizedString("LOCLuduRestProceedWithPruning", "LOCLuduRestProceedWithPruning"),
-                                System.Windows.MessageBoxButton.YesNo,
-                                System.Windows.MessageBoxImage.Question);
-
-                            if (proceedResult != System.Windows.MessageBoxResult.Yes)
-                                return;
                         });
+
+                        // Ask if user wants to proceed (outside Dispatcher.Invoke — Playnite handles dispatching)
+                        var proceedResult = PlayniteApi.Dialogs.ShowMessage(
+                            string.Format(GetLocalizedString("LOCLuduRestDryRunCompletedMessage", "LOCLuduRestDryRunCompletedMessage"), parsedDryRun.SnapshotsDeleted),
+                            GetLocalizedString("LOCLuduRestProceedWithPruning", "LOCLuduRestProceedWithPruning"),
+                            System.Windows.MessageBoxButton.YesNo,
+                            System.Windows.MessageBoxImage.Question);
+
+                        if (proceedResult != System.Windows.MessageBoxResult.Yes)
+                            return;
                     }
 
                     // Perform actual prune
@@ -776,7 +785,10 @@ namespace LudusaviRestic
 
         public override void OnApplicationStopped(OnApplicationStoppedEventArgs args)
         {
-            _timer?.Dispose();
+            foreach (var gameId in this._timers.Keys.ToList())
+            {
+                StopGameplayTimer(gameId);
+            }
         }
 
         public override void OnGameUninstalled(OnGameUninstalledEventArgs args)
@@ -794,9 +806,26 @@ namespace LudusaviRestic
             if (settings.BackupDuringGameplay)
             {
                 var interval = settings.GetEffectiveInterval(args.Game.Id);
-                this._timer = new Timer(GameplayBackupTimerElapsed, args.Game,
+                var timer = new Timer(GameplayBackupTimerElapsed, args.Game,
                     interval * 60000,
                     interval * 60000);
+
+                // Swap atomically: a separate remove-then-assign leaves a window in which
+                // an interleaved OnGameStopped orphans the timer we just created.
+                this._timers.AddOrUpdate(args.Game.Id, timer, (gameId, previous) =>
+                {
+                    previous.Dispose();
+                    return timer;
+                });
+            }
+        }
+
+        private void StopGameplayTimer(Guid gameId)
+        {
+            Timer existing;
+            if (this._timers.TryRemove(gameId, out existing))
+            {
+                existing.Dispose();
             }
         }
 
@@ -808,7 +837,9 @@ namespace LudusaviRestic
 
         public override void OnGameStopped(OnGameStoppedEventArgs args)
         {
-            this._timer?.Dispose();
+            if (args?.Game is null) return;
+
+            StopGameplayTimer(args.Game.Id);
 
             if (this.settings.BackupWhenGameStopped)
             {

--- a/src/LudusaviRestic.cs
+++ b/src/LudusaviRestic.cs
@@ -27,6 +27,10 @@ namespace LudusaviRestic
         private readonly System.Collections.Concurrent.ConcurrentDictionary<Guid, Timer> _timers =
             new System.Collections.Concurrent.ConcurrentDictionary<Guid, Timer>();
 
+        // Serializes start/stop for a game so a stop cannot run between constructing a
+        // timer and registering it, which would leave it firing against an ended session.
+        private readonly object _timerLock = new object();
+
         public LudusaviRestic(IPlayniteAPI api) : base(api)
         {
             this.settings = new LudusaviResticSettings(this);
@@ -806,26 +810,33 @@ namespace LudusaviRestic
             if (settings.BackupDuringGameplay)
             {
                 var interval = settings.GetEffectiveInterval(args.Game.Id);
-                var timer = new Timer(GameplayBackupTimerElapsed, args.Game,
-                    interval * 60000,
-                    interval * 60000);
 
-                // Swap atomically: a separate remove-then-assign leaves a window in which
-                // an interleaved OnGameStopped orphans the timer we just created.
-                this._timers.AddOrUpdate(args.Game.Id, timer, (gameId, previous) =>
+                lock (this._timerLock)
                 {
-                    previous.Dispose();
-                    return timer;
-                });
+                    var timer = new Timer(GameplayBackupTimerElapsed, args.Game,
+                        interval * 60000,
+                        interval * 60000);
+
+                    // Swap atomically: a separate remove-then-assign leaves a window in
+                    // which an interleaved OnGameStopped orphans the timer just created.
+                    this._timers.AddOrUpdate(args.Game.Id, timer, (gameId, previous) =>
+                    {
+                        previous.Dispose();
+                        return timer;
+                    });
+                }
             }
         }
 
         private void StopGameplayTimer(Guid gameId)
         {
-            Timer existing;
-            if (this._timers.TryRemove(gameId, out existing))
+            lock (this._timerLock)
             {
-                existing.Dispose();
+                Timer existing;
+                if (this._timers.TryRemove(gameId, out existing))
+                {
+                    existing.Dispose();
+                }
             }
         }
 

--- a/src/Models/BackupContext.cs
+++ b/src/Models/BackupContext.cs
@@ -1,5 +1,5 @@
 using Playnite.SDK;
-using System;
+using System.Collections.Generic;
 
 namespace LudusaviRestic
 {
@@ -16,7 +16,6 @@ namespace LudusaviRestic
         {
             this._api = api;
             this._settings = settings;
-            ApplyEnvironment();
         }
 
         public string UniqueNotificationID(string suffix)
@@ -24,12 +23,30 @@ namespace LudusaviRestic
             return $"LudusaviRestic_{suffix}";
         }
 
-        public void ApplyEnvironment()
+        /// <summary>
+        /// Builds the environment restic and rclone need, for application to a single
+        /// ProcessStartInfo. These must never be set on Playnite's own process block:
+        /// every game, launcher and emulator Playnite spawns inherits it, which would
+        /// disclose the repository password to arbitrary third-party executables.
+        /// </summary>
+        public IDictionary<string, string> BuildResticEnvironment()
         {
-            Environment.SetEnvironmentVariable("RCLONE_CONFIG_PASS", this._settings.RcloneConfigPassword);
-            Environment.SetEnvironmentVariable("RESTIC_REPOSITORY", this._settings.ResticRepository);
-            Environment.SetEnvironmentVariable("RESTIC_PASSWORD", this._settings.ResticPassword);
-            Environment.SetEnvironmentVariable("RCLONE_CONFIG", this._settings.RcloneConfigPath);
+            var environment = new Dictionary<string, string>();
+
+            AddIfSet(environment, "RCLONE_CONFIG_PASS", this._settings.RcloneConfigPassword);
+            AddIfSet(environment, "RESTIC_REPOSITORY", this._settings.ResticRepository);
+            AddIfSet(environment, "RESTIC_PASSWORD", this._settings.ResticPassword);
+            AddIfSet(environment, "RCLONE_CONFIG", this._settings.RcloneConfigPath);
+
+            return environment;
+        }
+
+        private static void AddIfSet(IDictionary<string, string> environment, string name, string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                environment[name] = value;
+            }
         }
     }
 }

--- a/src/Models/CommandResult.cs
+++ b/src/Models/CommandResult.cs
@@ -107,7 +107,7 @@ namespace LudusaviRestic
                 // Both waits share one deadline: waiting them independently would either
                 // double the worst-case bound or, if short-circuited, skip stderr entirely
                 // whenever stdout timed out first.
-                int deadline = Environment.TickCount + flushTimeoutMilliseconds;
+                int deadline = unchecked(Environment.TickCount + flushTimeoutMilliseconds);
                 bool stdoutFlushed = stdoutClosed.Wait(RemainingMilliseconds(deadline));
                 bool stderrFlushed = stderrClosed.Wait(RemainingMilliseconds(deadline));
 

--- a/src/Models/CommandResult.cs
+++ b/src/Models/CommandResult.cs
@@ -14,12 +14,18 @@ namespace LudusaviRestic
         private static readonly ILogger logger = LogManager.GetLogger();
 
         /// <summary>
-        /// Upper bound on a single restic/ludusavi invocation. Generous, because a first
-        /// backup or a "check --read-data" over a large repository legitimately takes a
-        /// long time; the point is to eventually release the backup semaphore rather than
-        /// to hold the session hostage to a wedged child process.
+        /// Last-resort bound on a single restic/ludusavi invocation. This exists only to
+        /// eventually release a *wedged* process, not to police how long legitimate work
+        /// may take, so it is deliberately far beyond any plausible real runtime.
+        ///
+        /// Sizing it tightly is a trap: "check --read-data" downloads and re-hashes the
+        /// entire repository, so it scales with repository size and backend latency, not
+        /// with anything the plugin controls. On a real 6 GiB rclone-backed repository a
+        /// metadata-only "check" already takes ~8 minutes, which puts the read-data
+        /// variant within striking distance of an hour on an average connection and past
+        /// it on a slow one — and repositories only grow.
         /// </summary>
-        internal const int DefaultTimeoutMilliseconds = 60 * 60 * 1000;
+        internal const int DefaultTimeoutMilliseconds = 24 * 60 * 60 * 1000;
 
         private int _exitCode;
         private string _stdout;

--- a/src/Models/CommandResult.cs
+++ b/src/Models/CommandResult.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
+using Playnite.SDK;
 
 [assembly: InternalsVisibleTo("LudusaviRestic.Tests")]
 
@@ -8,6 +11,16 @@ namespace LudusaviRestic
 {
     public class CommandResult
     {
+        private static readonly ILogger logger = LogManager.GetLogger();
+
+        /// <summary>
+        /// Upper bound on a single restic/ludusavi invocation. Generous, because a first
+        /// backup or a "check --read-data" over a large repository legitimately takes a
+        /// long time; the point is to eventually release the backup semaphore rather than
+        /// to hold the session hostage to a wedged child process.
+        /// </summary>
+        internal const int DefaultTimeoutMilliseconds = 60 * 60 * 1000;
+
         private int _exitCode;
         private string _stdout;
         private string _stderr;
@@ -23,19 +36,112 @@ namespace LudusaviRestic
             this._stderr = stderr;
         }
 
-        public CommandResult(Process process)
+        public CommandResult(Process process) : this(process, DefaultTimeoutMilliseconds)
         {
-            process.Start();
-            this._stdout = TransformProcessOutput(process.StandardOutput.ReadToEnd());
-            process.WaitForExit(4000);
-            this._stderr = TransformProcessOutput(process.StandardError.ReadToEnd());
-            this._exitCode = process.ExitCode;
         }
 
-        internal static string TransformProcessOutput(string output)
+        /// <summary>
+        /// How long to wait, after the child has exited, for its output pipes to reach EOF.
+        /// A grandchild that inherited the pipes (restic spawning rclone) can hold them open
+        /// after restic itself is gone, so this wait must be bounded: an unbounded one would
+        /// hang the caller and hold the backup semaphore for the rest of the session.
+        /// </summary>
+        internal const int StreamFlushTimeoutMilliseconds = 10 * 1000;
+
+        internal CommandResult(Process process, int timeoutMilliseconds)
+            : this(process, timeoutMilliseconds, StreamFlushTimeoutMilliseconds)
         {
-            byte[] bytes = Encoding.Default.GetBytes(output);
-            return Encoding.UTF8.GetString(bytes);
+        }
+
+        internal CommandResult(Process process, int timeoutMilliseconds, int flushTimeoutMilliseconds)
+        {
+            var stdout = new StringBuilder();
+            var stderr = new StringBuilder();
+            var outputLock = new object();
+
+            var stdoutClosed = new ManualResetEventSlim(false);
+            var stderrClosed = new ManualResetEventSlim(false);
+
+            // Both pipes must be drained concurrently. Reading one to EOF before touching
+            // the other deadlocks permanently as soon as the unread pipe's buffer fills
+            // (~4 KB), which restic reaches easily on any error-heavy run.
+            //
+            // A null Data signals EOF on that stream. The lock guards against a torn read
+            // if the flush wait below times out while a handler is still appending.
+            DataReceivedEventHandler onStdout = (sender, e) =>
+            {
+                if (e.Data == null) { stdoutClosed.Set(); }
+                else { lock (outputLock) { stdout.AppendLine(e.Data); } }
+            };
+            DataReceivedEventHandler onStderr = (sender, e) =>
+            {
+                if (e.Data == null) { stderrClosed.Set(); }
+                else { lock (outputLock) { stderr.AppendLine(e.Data); } }
+            };
+
+            process.OutputDataReceived += onStdout;
+            process.ErrorDataReceived += onStderr;
+
+            try
+            {
+                process.Start();
+
+                // Hand the child an immediately-closed stdin so anything that would prompt
+                // interactively (restic asking for a password) fails fast instead of hanging.
+                if (process.StartInfo.RedirectStandardInput)
+                {
+                    process.StandardInput.Close();
+                }
+
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
+                if (!process.WaitForExit(timeoutMilliseconds))
+                {
+                    TryKill(process);
+                    throw new TimeoutException(
+                        $"'{process.StartInfo.FileName}' did not exit within {timeoutMilliseconds} ms and was terminated");
+                }
+
+                // The child has exited, but its output may not have been delivered yet.
+                if (!stdoutClosed.Wait(flushTimeoutMilliseconds) ||
+                    !stderrClosed.Wait(flushTimeoutMilliseconds))
+                {
+                    logger.Warn($"'{process.StartInfo.FileName}' exited but its output streams did not " +
+                                "reach EOF; a surviving child process may still hold them. Output may be incomplete.");
+                }
+
+                this._exitCode = process.ExitCode;
+            }
+            finally
+            {
+                process.OutputDataReceived -= onStdout;
+                process.ErrorDataReceived -= onStderr;
+            }
+
+            lock (outputLock)
+            {
+                this._stdout = stdout.ToString();
+                this._stderr = stderr.ToString();
+            }
+
+            // Deliberately not disposed: an in-flight handler on a threadpool thread may
+            // still touch them after the unsubscribe above, and ObjectDisposedException
+            // there would be unobservable. They are finalizable and cost nothing to drop.
+        }
+
+        private static void TryKill(Process process)
+        {
+            try
+            {
+                if (!process.HasExited) { process.Kill(); }
+            }
+            catch (Exception e)
+            {
+                // Best-effort cleanup: the process may have exited between the check and
+                // the kill, and the timeout is reported either way.
+                logger.Debug(e, "Failed to terminate timed-out process");
+            }
         }
     }
 }

--- a/src/Models/CommandResult.cs
+++ b/src/Models/CommandResult.cs
@@ -104,8 +104,14 @@ namespace LudusaviRestic
                 }
 
                 // The child has exited, but its output may not have been delivered yet.
-                if (!stdoutClosed.Wait(flushTimeoutMilliseconds) ||
-                    !stderrClosed.Wait(flushTimeoutMilliseconds))
+                // Both waits share one deadline: waiting them independently would either
+                // double the worst-case bound or, if short-circuited, skip stderr entirely
+                // whenever stdout timed out first.
+                int deadline = Environment.TickCount + flushTimeoutMilliseconds;
+                bool stdoutFlushed = stdoutClosed.Wait(RemainingMilliseconds(deadline));
+                bool stderrFlushed = stderrClosed.Wait(RemainingMilliseconds(deadline));
+
+                if (!stdoutFlushed || !stderrFlushed)
                 {
                     logger.Warn($"'{process.StartInfo.FileName}' exited but its output streams did not " +
                                 "reach EOF; a surviving child process may still hold them. Output may be incomplete.");
@@ -128,6 +134,16 @@ namespace LudusaviRestic
             // Deliberately not disposed: an in-flight handler on a threadpool thread may
             // still touch them after the unsubscribe above, and ObjectDisposedException
             // there would be unobservable. They are finalizable and cost nothing to drop.
+        }
+
+        /// <summary>
+        /// Milliseconds left until <paramref name="deadline"/>, never negative. Uses
+        /// unchecked subtraction so a TickCount rollover still yields a correct interval.
+        /// </summary>
+        private static int RemainingMilliseconds(int deadline)
+        {
+            int remaining = unchecked(deadline - Environment.TickCount);
+            return remaining > 0 ? remaining : 0;
         }
 
         private static void TryKill(Process process)

--- a/src/Models/PruneResult.cs
+++ b/src/Models/PruneResult.cs
@@ -159,7 +159,7 @@ namespace LudusaviRestic
         private static void ParseDeletedSnapshotsText(PruneResult result, string output)
         {
             // Fallback text parsing for prune output
-            var lines = output.Split('\n');
+            var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (var line in lines)
             {
@@ -295,7 +295,7 @@ namespace LudusaviRestic
         private static void ParseForgetSnapshotsText(PruneResult result, string output)
         {
             // Fallback text parsing for forget output
-            var lines = output.Split('\n');
+            var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
             DeletedSnapshot currentSnapshot = null;
 
             foreach (var line in lines.Where(l => !string.IsNullOrWhiteSpace(l)))

--- a/src/Tasks/BaseBackupTask.cs
+++ b/src/Tasks/BaseBackupTask.cs
@@ -106,36 +106,72 @@ namespace LudusaviRestic
             return listfile;
         }
 
+        /// <summary>
+        /// Maps a restic exit code to a snapshot outcome. Only 0 means a snapshot was
+        /// written: restic 0.17+ also returns 10 (no repository), 11 (lock failed) and
+        /// 12 (wrong password), all of which previously reported success.
+        /// </summary>
+        internal static SnapshotResult MapExitCode(int exitCode)
+        {
+            switch (exitCode)
+            {
+                case 0:
+                    return SnapshotResult.Success;
+                case 3:
+                    return SnapshotResult.PartialFailure;
+                default:
+                    return SnapshotResult.Failed;
+            }
+        }
+
         internal static SnapshotResult CreateSnapshot(IList<string> files, BackupContext context, string game, IList<string> extraTags)
         {
             string listfile = WriteFilesToTempFile(files);
-            string tags = ConstructTags(game, extraTags);
-            string backupArgs = $"{tags} --files-from-verbatim \"{listfile}\"";
-
-            CommandResult process;
 
             try
             {
-                process = ResticCommand.Backup(context, backupArgs);
-            }
-            catch (Exception e)
-            {
-                logger.Debug(e, "Encountered error executing restic");
-                return SnapshotResult.Error;
-            }
+                string tags = ConstructTags(game, extraTags);
+                string backupArgs = $"{tags} --files-from-verbatim \"{listfile}\"";
 
-            switch (process.ExitCode)
+                CommandResult process;
+
+                try
+                {
+                    process = ResticCommand.Backup(context, backupArgs);
+                }
+                catch (Exception e)
+                {
+                    logger.Error(e, "Encountered error executing restic");
+                    return SnapshotResult.Error;
+                }
+
+                SnapshotResult result = MapExitCode(process.ExitCode);
+
+                switch (result)
+                {
+                    case SnapshotResult.PartialFailure:
+                        logger.Error($"Restic failed to read some game save files for {game}: {process.StdErr}");
+                        break;
+                    case SnapshotResult.Failed:
+                        logger.Error($"Failed to create restic game saves snapshot {game} (exit code {process.ExitCode}): {process.StdErr}");
+                        break;
+                }
+
+                return result;
+            }
+            finally
             {
-                case 1:
-                    logger.Error($"Failed to create restic game saves snapshot {game}");
-                    return SnapshotResult.Failed;
-                case 3:
-                    logger.Error($"Restic failed to read some game save files for {game}");
-                    return SnapshotResult.PartialFailure;
-                default:
-                    // Delete file list on success
+                try
+                {
                     System.IO.File.Delete(listfile);
-                    return SnapshotResult.Success;
+                }
+                catch (Exception e)
+                {
+                    // Cleanup only. GetTempFileName creates the file, so leaking one per
+                    // failed backup eventually exhausts the 65535-name limit, but failing
+                    // the backup over an undeletable temp file would be worse.
+                    logger.Warn(e, $"Failed to delete temporary file list {listfile}");
+                }
             }
         }
 

--- a/src/Utilities/ResticUtility.cs
+++ b/src/Utilities/ResticUtility.cs
@@ -11,6 +11,12 @@ namespace LudusaviRestic
         private static readonly ILogger logger = LogManager.GetLogger();
 
         /// <summary>
+        /// Timeout for executable detection probes. Detection walks a list of candidate
+        /// paths on the UI thread, so each probe must fail fast rather than block.
+        /// </summary>
+        private const int ProbeTimeoutMilliseconds = 10 * 1000;
+
+        /// <summary>
         /// Attempts to automatically detect the restic executable path
         /// </summary>
         /// <returns>The path to restic executable, or null if not found</returns>
@@ -130,64 +136,7 @@ namespace LudusaviRestic
         /// <returns>True if valid restic executable</returns>
         public static bool IsValidResticExecutable(string path)
         {
-            if (string.IsNullOrWhiteSpace(path))
-                return false;
-
-            try
-            {
-                // For "restic" (no path), check if it's available in PATH
-                if (path == "restic")
-                {
-                    using (var process = new Process
-                    {
-                        StartInfo = new ProcessStartInfo
-                        {
-                            FileName = "restic",
-                            Arguments = "version",
-                            UseShellExecute = false,
-                            RedirectStandardOutput = true,
-                            RedirectStandardError = true,
-                            CreateNoWindow = true,
-                            WindowStyle = ProcessWindowStyle.Hidden
-                        }
-                    })
-                    {
-                        process.Start();
-                        var output = process.StandardOutput.ReadToEnd();
-                        process.WaitForExit();
-                        return process.ExitCode == 0 && output.Contains("restic");
-                    }
-                }
-
-                // For full paths, check if file exists and is executable
-                if (!File.Exists(path))
-                    return false;
-
-                using (var fileProcess = new Process
-                {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = path,
-                        Arguments = "version",
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        CreateNoWindow = true,
-                        WindowStyle = ProcessWindowStyle.Hidden
-                    }
-                })
-                {
-                    fileProcess.Start();
-                    var fileOutput = fileProcess.StandardOutput.ReadToEnd();
-                    fileProcess.WaitForExit();
-                    return fileProcess.ExitCode == 0 && fileOutput.Contains("restic");
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.Debug($"Error checking restic executable at {path}: {ex.Message}");
-                return false;
-            }
+            return ProbeExecutable(path, "restic", "version", "restic");
         }
 
         /// <summary>
@@ -197,62 +146,32 @@ namespace LudusaviRestic
         /// <returns>True if valid ludusavi executable</returns>
         public static bool IsValidLudusaviExecutable(string path)
         {
+            return ProbeExecutable(path, "ludusavi", "--version", "ludusavi");
+        }
+
+        /// <summary>
+        /// Runs a version probe against a candidate executable. These run while settings
+        /// load, on Playnite's main thread, so the probe is given a short timeout: a path
+        /// on an unreachable network share would otherwise stall startup indefinitely.
+        /// </summary>
+        private static bool ProbeExecutable(string path, string bareName, string versionArgs, string expectedOutput)
+        {
             if (string.IsNullOrWhiteSpace(path))
+                return false;
+
+            // A bare name is resolved through PATH; anything else must exist on disk.
+            if (path != bareName && !File.Exists(path))
                 return false;
 
             try
             {
-                // For "ludusavi" (no path), check if it's available in PATH
-                if (path == "ludusavi")
-                {
-                    using (var process = new Process
-                    {
-                        StartInfo = new ProcessStartInfo
-                        {
-                            FileName = "ludusavi",
-                            Arguments = "--version",
-                            UseShellExecute = false,
-                            RedirectStandardOutput = true,
-                            RedirectStandardError = true,
-                            CreateNoWindow = true,
-                            WindowStyle = ProcessWindowStyle.Hidden
-                        }
-                    })
-                    {
-                        process.Start();
-                        var output = process.StandardOutput.ReadToEnd();
-                        process.WaitForExit();
-                        return process.ExitCode == 0 && output.ToLower().Contains("ludusavi");
-                    }
-                }
-
-                // For full paths, check if file exists and is executable
-                if (!File.Exists(path))
-                    return false;
-
-                using (var fileProcess = new Process
-                {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = path,
-                        Arguments = "--version",
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        CreateNoWindow = true,
-                        WindowStyle = ProcessWindowStyle.Hidden
-                    }
-                })
-                {
-                    fileProcess.Start();
-                    var fileOutput = fileProcess.StandardOutput.ReadToEnd();
-                    fileProcess.WaitForExit();
-                    return fileProcess.ExitCode == 0 && fileOutput.ToLower().Contains("ludusavi");
-                }
+                var result = BaseCommand.ExecuteCommand(path, versionArgs, null, ProbeTimeoutMilliseconds);
+                return result.ExitCode == 0
+                    && result.StdOut.IndexOf(expectedOutput, StringComparison.OrdinalIgnoreCase) >= 0;
             }
             catch (Exception ex)
             {
-                logger.Debug($"Error checking ludusavi executable at {path}: {ex.Message}");
+                logger.Debug($"Error checking {bareName} executable at {path}: {ex.Message}");
                 return false;
             }
         }
@@ -268,40 +187,15 @@ namespace LudusaviRestic
         {
             logger.Info($"Initializing restic repository at: {repositoryPath}");
 
-            // Create a temporary context with the new repository settings
-            var tempSettings = new LudusaviResticSettings
-            {
-                ResticExecutablePath = context.Settings.ResticExecutablePath,
-                ResticRepository = repositoryPath,
-                ResticPassword = password
-            };
+            // Start from the configured environment so an rclone-backed repository still
+            // resolves, then point restic at the repository being created.
+            var environment = context.BuildResticEnvironment();
+            environment["RESTIC_REPOSITORY"] = repositoryPath;
+            environment["RESTIC_PASSWORD"] = password;
 
-            var tempContext = new BackupContext(context.API, tempSettings);
+            logger.Debug($"Repository: {repositoryPath}");
 
-            // Execute restic init command
-            using (var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = tempSettings.ResticExecutablePath,
-                    Arguments = "init",
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true,
-                    WindowStyle = ProcessWindowStyle.Hidden
-                }
-            })
-            {
-                // Set environment variables for restic
-                process.StartInfo.Environment["RESTIC_REPOSITORY"] = repositoryPath;
-                process.StartInfo.Environment["RESTIC_PASSWORD"] = password;
-
-                logger.Debug($"Executing: {process.StartInfo.FileName} {process.StartInfo.Arguments}");
-                logger.Debug($"Repository: {repositoryPath}");
-
-                return new CommandResult(process);
-            }
+            return BaseCommand.ExecuteCommand(context.Settings.ResticExecutablePath.Trim(), "init", environment);
         }
 
         /// <summary>

--- a/tests/BackupContextTests.cs
+++ b/tests/BackupContextTests.cs
@@ -43,5 +43,85 @@ namespace LudusaviRestic.Tests
 
             Assert.Equal("LudusaviRestic_", context.UniqueNotificationID(""));
         }
+
+        [Fact]
+        public void BuildResticEnvironment_PopulatesConfiguredVariables()
+        {
+            var context = new BackupContext(null, new LudusaviResticSettings
+            {
+                ResticRepository = "C:\\repo",
+                ResticPassword = "hunter2",
+                RcloneConfigPath = "C:\\rclone.conf",
+                RcloneConfigPassword = "rclone-pass"
+            });
+
+            var environment = context.BuildResticEnvironment();
+
+            Assert.Equal("C:\\repo", environment["RESTIC_REPOSITORY"]);
+            Assert.Equal("hunter2", environment["RESTIC_PASSWORD"]);
+            Assert.Equal("C:\\rclone.conf", environment["RCLONE_CONFIG"]);
+            Assert.Equal("rclone-pass", environment["RCLONE_CONFIG_PASS"]);
+        }
+
+        /// <summary>
+        /// Unset values must be omitted rather than written as empty strings, so an rclone
+        /// config inherited from the user's own environment is not blanked out.
+        /// </summary>
+        [Fact]
+        public void BuildResticEnvironment_OmitsUnsetVariables()
+        {
+            var context = new BackupContext(null, new LudusaviResticSettings
+            {
+                ResticRepository = "C:\\repo",
+                ResticPassword = "hunter2"
+            });
+
+            var environment = context.BuildResticEnvironment();
+
+            Assert.False(environment.ContainsKey("RCLONE_CONFIG"));
+            Assert.False(environment.ContainsKey("RCLONE_CONFIG_PASS"));
+        }
+
+        [Fact]
+        public void BuildResticEnvironment_OmitsEmptyStrings()
+        {
+            var context = new BackupContext(null, new LudusaviResticSettings
+            {
+                ResticRepository = "C:\\repo",
+                RcloneConfigPath = "",
+                RcloneConfigPassword = ""
+            });
+
+            var environment = context.BuildResticEnvironment();
+
+            Assert.False(environment.ContainsKey("RCLONE_CONFIG"));
+            Assert.False(environment.ContainsKey("RCLONE_CONFIG_PASS"));
+        }
+
+        /// <summary>
+        /// Constructing a context previously wrote the repository password into Playnite's
+        /// own process block, which every launched game inherited.
+        /// </summary>
+        [Fact]
+        public void Constructor_DoesNotWriteToProcessEnvironment()
+        {
+            var original = System.Environment.GetEnvironmentVariable("RESTIC_PASSWORD");
+            System.Environment.SetEnvironmentVariable("RESTIC_PASSWORD", null);
+
+            try
+            {
+                new BackupContext(null, new LudusaviResticSettings
+                {
+                    ResticRepository = "C:\\repo",
+                    ResticPassword = "hunter2"
+                });
+
+                Assert.Null(System.Environment.GetEnvironmentVariable("RESTIC_PASSWORD"));
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable("RESTIC_PASSWORD", original);
+            }
+        }
     }
 }

--- a/tests/CommandResultTests.cs
+++ b/tests/CommandResultTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Text;
 using Xunit;
 
@@ -6,53 +8,6 @@ namespace LudusaviRestic.Tests
     public class CommandResultTests
     {
         [Fact]
-        public void TransformProcessOutput_PlainAscii_RoundTrips()
-        {
-            var result = CommandResult.TransformProcessOutput("hello world");
-
-            Assert.Equal("hello world", result);
-        }
-
-        [Fact]
-        public void TransformProcessOutput_EmptyString_ReturnsEmpty()
-        {
-            var result = CommandResult.TransformProcessOutput("");
-
-            Assert.Equal("", result);
-        }
-
-        // Simulate process stdout: UTF-8 bytes misread via Encoding.Default
-        private static string SimulateGarbledProcessOutput(string original)
-        {
-            byte[] utf8Bytes = Encoding.UTF8.GetBytes(original);
-            return Encoding.Default.GetString(utf8Bytes);
-        }
-
-        [Fact]
-        public void TransformProcessOutput_UnicodeGreekSigma_PreservesCharacter()
-        {
-            // Simulate what .NET's Process.StandardOutput.ReadToEnd() produces
-            // when the process writes UTF-8 but .NET reads with Encoding.Default
-            var garbled = SimulateGarbledProcessOutput("Ninja Gaiden \u03A3");
-
-            var result = CommandResult.TransformProcessOutput(garbled);
-
-            Assert.Equal("Ninja Gaiden \u03A3", result);
-        }
-
-        [Fact]
-        public void TransformProcessOutput_UnicodeJsonWithSpecialChars_Preserved()
-        {
-            var original = "{\"games\":{\"Ninja Gaiden \u03A3\":{\"files\":{\"C:/Save/\u03A3.dat\":{}}}}}";
-            var garbled = SimulateGarbledProcessOutput(original);
-
-            var result = CommandResult.TransformProcessOutput(garbled);
-
-            Assert.Contains("Ninja Gaiden \u03A3", result);
-            Assert.Contains("\u03A3.dat", result);
-        }
-
-        [Fact]
         public void InternalConstructor_SetsProperties()
         {
             var result = new CommandResult(42, "out", "err");
@@ -60,6 +15,197 @@ namespace LudusaviRestic.Tests
             Assert.Equal(42, result.ExitCode);
             Assert.Equal("out", result.StdOut);
             Assert.Equal("err", result.StdErr);
+        }
+
+        [Fact]
+        public void Execute_CapturesExitCode()
+        {
+            var result = BaseCommand.ExecuteCommand("cmd.exe", "/d /c exit 12", null);
+
+            Assert.Equal(12, result.ExitCode);
+        }
+
+        [Fact]
+        public void Execute_CapturesStdOutAndStdErrSeparately()
+        {
+            var result = BaseCommand.ExecuteCommand("cmd.exe", "/d /c echo to-stdout& echo to-stderr 1>&2", null);
+
+            Assert.Contains("to-stdout", result.StdOut);
+            Assert.DoesNotContain("to-stderr", result.StdOut);
+            Assert.Contains("to-stderr", result.StdErr);
+        }
+
+        /// <summary>
+        /// Writes a file large enough to overflow a pipe buffer, and returns the marker
+        /// text present on its last line.
+        /// </summary>
+        private static string WriteBulkFile(string path, string marker)
+        {
+            var content = new StringBuilder();
+            for (int i = 1; i <= 300; i++)
+            {
+                content.AppendLine($"{marker}-line-{i}-padding-padding-padding-padding");
+            }
+            File.WriteAllText(path, content.ToString());
+            return $"{marker}-line-300-";
+        }
+
+        /// <summary>
+        /// Regression test for the pipe deadlock: stdout was read to EOF before stderr was
+        /// touched, so anything past the ~4 KB stderr buffer hung the call forever. This
+        /// exact command reproduces the hang against the previous implementation.
+        /// </summary>
+        [Fact]
+        public void Execute_LargeStdErr_DoesNotDeadlock()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                string lastLine = WriteBulkFile(path, "bulk");
+
+                var result = BaseCommand.ExecuteCommand("cmd.exe", $"/d /c type \"{path}\" 1>&2", null);
+
+                Assert.Equal(0, result.ExitCode);
+                Assert.True(result.StdErr.Length > 4096, $"expected >4 KB of stderr, got {result.StdErr.Length}");
+                Assert.Contains(lastLine, result.StdErr);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Execute_LargeOutputOnBothStreams_DoesNotDeadlock()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                string lastLine = WriteBulkFile(path, "bulk");
+
+                var result = BaseCommand.ExecuteCommand(
+                    "cmd.exe", $"/d /c type \"{path}\" & type \"{path}\" 1>&2", null);
+
+                Assert.Equal(0, result.ExitCode);
+                Assert.True(result.StdOut.Length > 4096, $"expected >4 KB of stdout, got {result.StdOut.Length}");
+                Assert.True(result.StdErr.Length > 4096, $"expected >4 KB of stderr, got {result.StdErr.Length}");
+                Assert.Contains(lastLine, result.StdOut);
+                Assert.Contains(lastLine, result.StdErr);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        /// <summary>
+        /// restic emits UTF-8; without an explicit StandardOutputEncoding the stream is
+        /// decoded using the console code page and non-ASCII game names are mangled.
+        /// </summary>
+        [Fact]
+        public void Execute_Utf8Output_DecodedCorrectly()
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                // No BOM: exactly the byte stream restic would produce.
+                File.WriteAllText(path, "Ninja Gaiden Σ — 日本語", new UTF8Encoding(false));
+
+                var result = BaseCommand.ExecuteCommand("cmd.exe", $"/d /c type \"{path}\"", null);
+
+                Assert.Contains("Ninja Gaiden Σ", result.StdOut);
+                Assert.Contains("日本語", result.StdOut);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Execute_PassesEnvironmentToChildProcess()
+        {
+            var environment = new System.Collections.Generic.Dictionary<string, string>
+            {
+                { "LUDUREST_TEST_VAR", "expected-value" }
+            };
+
+            var result = BaseCommand.ExecuteCommand("cmd.exe", "/d /c echo %LUDUREST_TEST_VAR%", environment);
+
+            Assert.Contains("expected-value", result.StdOut);
+        }
+
+        /// <summary>
+        /// The environment must reach the child only, never Playnite's own process block,
+        /// which every launched game would inherit.
+        /// </summary>
+        [Fact]
+        public void Execute_DoesNotLeakEnvironmentIntoCurrentProcess()
+        {
+            var environment = new System.Collections.Generic.Dictionary<string, string>
+            {
+                { "LUDUREST_LEAK_CHECK", "secret" }
+            };
+
+            BaseCommand.ExecuteCommand("cmd.exe", "/d /c exit 0", environment);
+
+            Assert.Null(Environment.GetEnvironmentVariable("LUDUREST_LEAK_CHECK"));
+        }
+
+        /// <summary>
+        /// A grandchild that inherited the pipes can outlive the process we launched. The
+        /// EOF wait must be bounded, or this call would never return and would hold the
+        /// backup semaphore for the rest of the session.
+        /// </summary>
+        [Fact]
+        public void Execute_SurvivingGrandchildHoldingPipes_StillReturns()
+        {
+            var process = new System.Diagnostics.Process();
+            // cmd exits immediately; the backgrounded ping inherits its stdout/stderr and
+            // keeps the pipe write-ends open well past cmd's own exit.
+            process.StartInfo.FileName = "cmd.exe";
+            process.StartInfo.Arguments = "/d /c start /b ping -n 30 127.0.0.1";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+
+            using (process)
+            {
+                var started = System.DateTime.UtcNow;
+
+                // Short flush timeout so the test proves boundedness without waiting it out.
+                var result = new CommandResult(process, CommandResult.DefaultTimeoutMilliseconds, 1000);
+
+                var elapsed = System.DateTime.UtcNow - started;
+
+                Assert.Equal(0, result.ExitCode);
+                Assert.True(elapsed.TotalSeconds < 15,
+                    $"call must be bounded by the flush timeout, took {elapsed.TotalSeconds:F1}s");
+            }
+        }
+
+        [Fact]
+        public void Execute_ProcessExceedingTimeout_IsTerminated()
+        {
+            var process = new System.Diagnostics.Process();
+            // ping directly rather than via cmd.exe: killing a cmd wrapper leaves the
+            // grandchild alive holding the pipes, which orphans a process and stalls
+            // the run until it exits on its own.
+            process.StartInfo.FileName = "ping.exe";
+            process.StartInfo.Arguments = "-n 10 127.0.0.1";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+
+            using (process)
+            {
+                Assert.Throws<TimeoutException>(() => new CommandResult(process, 1000));
+
+                // Kill is asynchronous; give TerminateProcess a moment rather than racing it.
+                Assert.True(process.WaitForExit(10000), "timed-out process should have been killed");
+            }
         }
     }
 }

--- a/tests/SnapshotExitCodeTests.cs
+++ b/tests/SnapshotExitCodeTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+
+namespace LudusaviRestic.Tests
+{
+    public class SnapshotExitCodeTests
+    {
+        [Fact]
+        public void MapExitCode_Zero_IsSuccess()
+        {
+            Assert.Equal(SnapshotResult.Success, BaseBackupTask.MapExitCode(0));
+        }
+
+        [Fact]
+        public void MapExitCode_Three_IsPartialFailure()
+        {
+            Assert.Equal(SnapshotResult.PartialFailure, BaseBackupTask.MapExitCode(3));
+        }
+
+        [Fact]
+        public void MapExitCode_One_IsFailed()
+        {
+            Assert.Equal(SnapshotResult.Failed, BaseBackupTask.MapExitCode(1));
+        }
+
+        /// <summary>
+        /// restic 0.17+ exit codes that previously fell through to "success": the backup
+        /// reported a green notification while nothing had been written.
+        /// </summary>
+        [Theory]
+        [InlineData(10)] // no repository
+        [InlineData(11)] // failed to lock repository
+        [InlineData(12)] // wrong password
+        public void MapExitCode_ResticFailureCodes_AreFailed(int exitCode)
+        {
+            Assert.Equal(SnapshotResult.Failed, BaseBackupTask.MapExitCode(exitCode));
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(4)]
+        [InlineData(130)]
+        [InlineData(-1)]
+        public void MapExitCode_UnknownNonZeroCodes_AreFailed(int exitCode)
+        {
+            Assert.Equal(SnapshotResult.Failed, BaseBackupTask.MapExitCode(exitCode));
+        }
+    }
+}


### PR DESCRIPTION
Addresses the `playnite-ludusavi-restic` findings from the [July 2026 code review](https://outline.sharkus.xyz/doc/playnite-extensions-code-review-july-2026-Bxx1LU9EoP). All seven findings were verified against the code before fixing; line numbers in the audit matched exactly.

Releases as **1.3.1** (`extension.yaml` + `manifest.yaml` updated, changelog written, version/PackageUrl validation passes).

## Tier 1 — security

**Repository password leaked to every launched process** — `src/Models/BackupContext.cs`

`ApplyEnvironment()` called `Environment.SetEnvironmentVariable` with no target, which writes to Playnite's *own* process block. Every game, launcher and emulator Playnite spawns inherited `RESTIC_PASSWORD`, `RCLONE_CONFIG_PASS`, `RESTIC_REPOSITORY` and `RCLONE_CONFIG`.

Credentials are now built per-invocation via `BuildResticEnvironment()` and applied to `ProcessStartInfo.Environment`, the pattern `InitializeRepository` already used. Unset values are omitted rather than written as empty strings, so an rclone config inherited from the user's own environment is not blanked out.

## Tier 1 — data loss

**"Proceed with pruning?" was not binding** — `src/LudusaviRestic.cs`

The `return` sat inside a `Dispatcher.Invoke` lambda, so it exited the lambda rather than the action, and control fell straight through to `ResticCommand.Prune(context)`. Clicking **No** pruned the repository anyway. Hoisted out of the lambda, matching the pattern already used correctly in `RunPruneMaintenance` and `RunRetentionMaintenance`.

**restic failures reported as successful snapshots** — `src/Tasks/BaseBackupTask.cs`

The exit-code switch knew only 1 and 3. restic ≥0.17 also returns 10 (no repository), 11 (failed to lock) and 12 (**wrong password**) — all hit `default:` and returned `SnapshotResult.Success`, so users got a green "Snapshot created successfully" with nothing written.

Extracted as a pure `MapExitCode` where only 0 is success. stderr is now included in the failure log, which is what actually diagnoses these cases.

## Tier 3 — reliability

**Pipe deadlock** — `src/Models/CommandResult.cs`

`StandardOutput.ReadToEnd()` ran to completion before stderr was touched, so anything past the ~4 KB stderr buffer hung forever. Because `BackupGameTask.Backup` holds `semaphore.Wait()` across the call, every subsequent backup in the session blocked behind it.

Reproduced empirically: a script using the same sequential reads against a >4 KB stderr producer hung and had to be killed. Both pipes are now drained concurrently via `OutputDataReceived`/`ErrorDataReceived`.

The same method also got:
- **Bounded EOF wait.** A grandchild that inherited the pipes (restic spawning `rclone`) can outlive its parent and hold them open. A bare `WaitForExit()` there would reintroduce the exact hang being fixed, so the flush wait has its own timeout and logs when it expires.
- **Explicit UTF-8 decoding**, replacing a lossy `Encoding.Default.GetBytes` → `UTF8.GetString` re-transcode that was compensating for never setting `StandardOutputEncoding`. Any character outside the ANSI code page was destroyed as `?` before the "fix" ran.
- **A real timeout** that terminates a wedged child, `using` on the `Process` (was leaking handles), and closed stdin so an interactive password prompt fails fast instead of hanging.

**Gameplay timers leaked across games** — `src/LudusaviRestic.cs`

`_timer` was a single field. Start game A → start game B → stop B disposed only B's timer; A's kept firing for the rest of the session, backing up A and pinning a stale `Game`. Now keyed by `Game.Id` in a `ConcurrentDictionary`, swapped atomically via `AddOrUpdate`, and drained in `OnApplicationStopped`.

**Tag applied but never persisted** — `src/LudusaviRestic.cs`

`AddTag` returned `false` on the `else` branch — the one that actually assigns `game.TagIds` — so the caller skipped `Games.Update`. Games with no existing tags appeared tagged until restart.

## Beyond the audit

Found while fixing the above:

- **`RCLONE_CONFIG` clobbered session-wide.** `InitializeRepository` built a throwaway `BackupContext` whose constructor applied an environment derived from settings that had no rclone values, *deleting* `RCLONE_CONFIG` for the rest of the session. It now takes the configured environment and overrides only the repository and password, so rclone-backed repositories initialize correctly.
- **Temp file leak.** `File.Delete(listfile)` lived only on the success path, so every failed backup leaked a file. `Path.GetTempFileName` creates the file and caps at 65535 names, so this eventually throws. Now deleted in a `finally` on all outcomes.
- **Executable-detection probes.** `IsValidResticExecutable`/`IsValidLudusaviExecutable` were two more copies of the sequential-`ReadToEnd` pattern, with unbounded waits and no encoding. They run while settings load *on the UI thread*, so a configured path on an unreachable network share could stall Playnite startup indefinitely. Both now share the fixed process path with a short probe timeout.
- **CRLF in the text parsers.** Draining line-by-line rejoins with `Environment.NewLine`, so `PruneResult`'s fallback parsers splitting on `'\n'` would see a trailing `'\r'`. Both splits now handle either. (Reachable only if a `--json` call ever stops passing `--json`, but it is a real behavior delta.)

## Repo hygiene — unblocks all 10 open Renovate PRs

`.github/workflows/claude-code-review.yml` had **two trailing newlines**, failing the `end-of-file-fixer` hook. That is why every open PR shows `pre-commit=FAILURE` — it was never the PRs' fault. Once this merges, all 10 should go green.

The pre-commit `format` hook also pointed at `src/`, which is ambiguous now that both `src.sln` and `LudusaviRestic.csproj` live there; newer .NET SDKs refuse to resolve it. Pointed at the csproj explicitly.

## Testing

**184 pass**, 0 fail. New coverage for the exit-code mapping, the pipe deadlock, the bounded flush, UTF-8 decoding, the process timeout and the environment builder.

These fail or hang against the previous implementation, so they are genuine regression tests:

| Test | Against old code |
|---|---|
| `MapExitCode` for 10/11/12 | fails — returned `Success` |
| `Constructor_DoesNotWriteToProcessEnvironment` | fails — ctor called `ApplyEnvironment()` |
| `Execute_LargeStdErr_DoesNotDeadlock` | **hangs** |
| `Execute_LargeOutputOnBothStreams_DoesNotDeadlock` | **hangs** |
| `Execute_Utf8Output_DecodedCorrectly` | fails — CJK became `?` |
| `Execute_ProcessExceedingTimeout_IsTerminated` | fails — no timeout existed |

Tests invoke `cmd.exe` with `/d` deliberately, to skip any machine-local `AutoRun` entry.

Also verified locally against this branch: open Renovate PRs #120, #126, #127, #128 and #129 all build and pass 184 tests. **#130 cannot be merged** — `xunit.runner.visualstudio` 3.1.5 dropped net462 support (`NU1202`, requires net472+).

## Notes for review

- The 60-minute command timeout is a constant. `restic check --read-data` over a very large or remote repository could legitimately exceed it and would now be killed. Worth deciding whether to raise it or make it configurable.
- Killing a wedged restic can leave a stale repository lock until it expires; that surfaces as exit 11, which this PR now correctly reports as a failure rather than a success.
- `MapExitCode` widens 1 → `Failed` (unchanged) and moves 10/11/12 from a false success into the existing error path. No consumer distinguishes `Failed` from `Error`, so no notification logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
